### PR TITLE
Fix attendance route to avoid redirect

### DIFF
--- a/backend/app/attendance.py
+++ b/backend/app/attendance.py
@@ -135,7 +135,7 @@ def summary(employee:str=Query(...), month:str=Query(None)):
     return _update_summary(ws, employee, month)
 
 # ---------- Simplified attendance endpoint ----------
-@router.post("/")
+@router.post("")
 def record_attendance(ev: AttendanceEvent):
     tab_name = ev.employee.capitalize()
     try:


### PR DESCRIPTION
## Summary
- update POST route for simplified attendance endpoint

## Testing
- `python -m py_compile backend/app/attendance.py backend/app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_685ec44536b083218f83209e2c33fb21