### PR TITLE
Refactor to use per‑employee tables only

### DIFF
--- a/backend/app/attendance.py
+++ b/backend/app/attendance.py
@@ -70,9 +70,17 @@ def _ws(emp:str):
         return ss.worksheet(emp)
     ws = ss.add_worksheet(title=emp, rows="1000", cols=str(len(HEADER)))
     ws.append_row(HEADER)
-    ws.format("1:1", {"textFormat":{"bold":True}, "backgroundColor":{"red":.9,"green":.9,"blue":.9}})
+    ws.format("1:1", {
+        "textFormat": {"bold": True},
+        "backgroundColor": {"red": .9, "green": .9, "blue": .9},
+        "borders": {"bottom": {"style": "SOLID_THICK", "color": {"red": 0, "green": 0, "blue": 0}}}
+    })
     ws.freeze(rows=2)
     ws.insert_row([""]*len(HEADER), 2)   # summary row
+    ws.format("2:2", {
+        "textFormat": {"bold": True},
+        "borders": {"bottom": {"style": "SOLID_THICK", "color": {"red": 0.29, "green": 0.53, "blue": 0.91}}}
+    })
     return ws
 
 def _month_sep(ws, month):
@@ -80,6 +88,9 @@ def _month_sep(ws, month):
     last   = next((m for m in reversed(months) if m), "")
     if last != month:
         ws.insert_rows(row=3, number=2)
+        ws.format("3:3", {
+            "borders": {"top": {"style": "SOLID_THICK", "color": {"red": 0, "green": 0, "blue": 0}}}
+        })
 
 # ----- Legacy attendance table helpers ---------------------------
 def _attendance_sheet():
@@ -290,8 +301,7 @@ def record_attendance(ev: AttendanceEvent):
 
         ws.append_row([local_dt.strftime("%Y-%m-%d %H:%M:%S"), ev.action])
 
-        # also store in legacy table-style sheet
-        record_attendance_table(ev.employee, ev.action, local_dt)
+        # legacy attendance table is no longer used
 
         return {"ok": True}
     except Exception as e:

--- a/static/index.html
+++ b/static/index.html
@@ -339,7 +339,8 @@
           ts:       new Date().toISOString()
         };
 
-        apiPost('/attendance', payload)
+        // Store data directly in the per-employee table
+        apiPost('/attendance/clock', payload)
           .then(r  => document.getElementById('msg').innerHTML = '✅ Saved!')
           .catch(e => document.getElementById('msg').innerHTML = '❌ ' + e.message);
       }


### PR DESCRIPTION
## Summary
- stop writing to the legacy `Attendance` sheet
- store records through `/attendance/clock` from the web page
- format employee tabs with thick borders for clarity

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ecc5287388321bcc48caf2181dfc6