### PR TITLE
Refactor to use per-employee tables only

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -339,7 +339,8 @@
           ts:       new Date().toISOString()
         };
 
-        apiPost('/attendance', payload)
+        // Store data directly in the per-employee table
+        apiPost('/attendance/clock', payload)
           .then(r  => document.getElementById('msg').innerHTML = '✅ Saved!')
           .catch(e => document.getElementById('msg').innerHTML = '❌ ' + e.message);
       }


### PR DESCRIPTION
## Summary
- stop writing to the legacy `Attendance` sheet
- store records through `/attendance/clock` from the web page
- format employee tabs with thick borders for clarity
- ensure legacy sheet has enough columns if accessed

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685ecc5287388321bcc48caf2181dfc6