### PR TITLE
Restore legacy attendance table

### DIFF
--- a/backend/app/attendance.py
+++ b/backend/app/attendance.py
@@ -280,6 +280,8 @@ def clock(body: ClockBody):
         iso(now) if body.action=="startextra" else "",
         iso(now) if body.action=="endextra"   else ""
     ])
+    # also store data in the legacy day‑oriented table
+    record_attendance_table(body.employee, body.action, now)
     return _update_summary(ws, body.employee, mon)
 
 @router.get("/summary", response_model=Summary)


### PR DESCRIPTION
## Summary
- update `clock` route to also store each action in the legacy day-oriented table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ef0e86b30832191605d5de0a3d94b