### PR TITLE
Add httpx dependency

### DIFF
--- a/backend/requirements-dev.txt
+++ b/backend/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ google-auth==2.29.0
 google-auth-oauthlib==1.2.0
 google-auth-httplib2==0.2.0
 google-api-python-client==2.129.0
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- include `httpx` in backend requirements so `fastapi.testclient` works
- add `backend/requirements-dev.txt` for local test installs

## Testing
- `pytest -q tests/test_clock_transition.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ef383fcdc83219395151ecf03c09f