### PR TITLE
Remove raw logs from clock API

### DIFF
--- a/backend/app/attendance.py
+++ b/backend/app/attendance.py
@@ -132,9 +132,9 @@ def _ensure_month_grid(ws, emp: str, month: str) -> None:
 
     # 3) labels in col A, rows 2-11
     labels = [
-        emp, "(Out)", "(Duration)", "(Work Outcome)",
-        "(Break Start)", "(Break End)", "(Break Outcome)",
-        "(Extra Start)", "(Extra End)", "(Extra Outcome)"
+        "(Main-In)", "(Main-Out)", "(Duration)", "(Work Outcome)",
+        "(Break-In)", "(Break-Out)", "(Break Outcome)",
+        "(Extra-In)", "(Extra-Out)", "(Extra Outcome)"
     ]
     ws.update("A2:A11", [[l] for l in labels])
 
@@ -362,15 +362,6 @@ def clock(body: ClockBody):
 
         def iso(t): return t.isoformat() if t else ""
 
-        ws.append_row([
-            now.isoformat(), body.action, body.dayflag, mon,
-            iso(now) if body.action=="clockin"   else "",
-            iso(now) if body.action=="clockout"  else "",
-            iso(now) if body.action=="startbreak" else "",
-            iso(now) if body.action=="endbreak"   else "",
-            iso(now) if body.action=="startextra" else "",
-            iso(now) if body.action=="endextra"   else ""
-        ])
         # NEW – keep the per-employee month grid in sync
         _ensure_month_grid(ws, body.employee, mon)
         _record_into_grid(ws, body.action, now)

--- a/tests/test_clock_transition.py
+++ b/tests/test_clock_transition.py
@@ -22,6 +22,7 @@ fake_ws.append_row = MagicMock()
 fake_ws.freeze = MagicMock()
 fake_ws.insert_row = MagicMock()
 fake_ws.update_cell = MagicMock()
+fake_ws.update = MagicMock()
 fake_ws.col_count = 0
 fake_ws.add_cols = MagicMock()
 fake_ws.acell = MagicMock(return_value=MagicMock(value=""))
@@ -78,11 +79,11 @@ def test_empty_month_rows_do_not_error():
 
 
 def test_clock_failing_returns_friendly_error():
-    fake_ws.append_row.side_effect = Exception("gs fail")
+    fake_ws.update.side_effect = Exception("gs fail")
     resp = client.post('/attendance/clock', json={
         'employee': 'Alice',
         'action': 'clockin'
     })
     assert resp.status_code == 500
     assert resp.json() == {'detail': 'Failed to record attendance'}
-    fake_ws.append_row.side_effect = None
+    fake_ws.update.side_effect = None


### PR DESCRIPTION
## Summary
- update month grid labels for action rows
- stop appending legacy log rows in `clock`
- adjust tests for new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685f0682a1388321908c1518d01ec085