### PR TITLE
Improve monthly table labels

### DIFF
--- a/backend/app/attendance.py
+++ b/backend/app/attendance.py
@@ -182,17 +182,18 @@ def _ensure_month_grid(ws, emp: str, month: str) -> None:
     )
 
     # 3) labels in col A, rows 2-11
+    # First column labels – updated to match the UI table
     labels = [
-        "(Main-In)",
-        "(Main-Out)",
-        "(Duration)",
-        "(Work Outcome)",
-        "(Break-In)",
-        "(Break-Out)",
-        "(Break Outcome)",
-        "(Extra-In)",
-        "(Extra-Out)",
-        "(Extra Outcome)",
+        "Clock-In",
+        "Clock-Out",
+        "Main (h m)",
+        "Break-Start",
+        "Break-End",
+        "Break (min)",
+        "Extra-Start",
+        "Extra-End",
+        "Extra (min)",
+        "Outcome",
     ]
     ws.update("A2:A11", [[l] for l in labels])
 

--- a/static/index.html
+++ b/static/index.html
@@ -360,7 +360,11 @@
           body: JSON.stringify({ employee: employeeName, action })
         })
         .then(r => r.json())
-        .then(j => document.getElementById("msg").innerText = j.message)
+        .then(j => {
+          document.getElementById("msg").innerText = j.message;
+          // Refresh month grid after any punch
+          loadMonthData();
+        })
         .catch(e => document.getElementById("msg").innerText = '❌ '+e);
       }
 
@@ -463,11 +467,25 @@
         html += '</tr></thead><tbody>';
         data.rows.forEach(r => {
           html += '<tr>';
-          r.forEach(c => html += `<td>${c||''}</td>`);
+          r.forEach(c => html += `<td>${formatTableCell(c)}</td>`);
           html += '</tr>';
         });
         html += '</tbody></table>';
         document.getElementById('monthTable').innerHTML = html;
+      }
+
+      function formatTableCell(val){
+        if(val === null || val === undefined) return '';
+        if(!isNaN(val) && val !== ''){
+          let num = parseFloat(val);
+          if(num >= 0 && num < 1){
+            let total = Math.round(num * 24 * 60);
+            let h = String(Math.floor(total / 60)).padStart(2,'0');
+            let m = String(total % 60).padStart(2,'0');
+            return `${h}:${m}`;
+          }
+        }
+        return val;
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- update grid row labels to match UI wording
- refresh month view data after each action
- format numeric time values when drawing month table

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685f174b94548321a4aaae6d8abfcc40