### PR TITLE
Remove duplicate month grid rows

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -360,7 +360,11 @@
           body: JSON.stringify({ employee: employeeName, action })
         })
         .then(r => r.json())
-        .then(j => document.getElementById("msg").innerText = j.message)
+        .then(j => {
+          document.getElementById("msg").innerText = j.message;
+          // Refresh month grid after any punch
+          loadMonthData();
+        })
         .catch(e => document.getElementById("msg").innerText = '❌ '+e);
       }
 
@@ -463,11 +467,25 @@
         html += '</tr></thead><tbody>';
         data.rows.forEach(r => {
           html += '<tr>';
-          r.forEach(c => html += `<td>${c||''}</td>`);
+          r.forEach(c => html += `<td>${formatTableCell(c)}</td>`);
           html += '</tr>';
         });
         html += '</tbody></table>';
         document.getElementById('monthTable').innerHTML = html;
+      }
+
+      function formatTableCell(val){
+        if(val === null || val === undefined) return '';
+        if(!isNaN(val) && val !== ''){
+          let num = parseFloat(val);
+          if(num >= 0 && num < 1){
+            let total = Math.round(num * 24 * 60);
+            let h = String(Math.floor(total / 60)).padStart(2,'0');
+            let m = String(total % 60).padStart(2,'0');
+            return `${h}:${m}`;
+          }
+        }
+        return val;
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- simplify new worksheets to avoid legacy log headers
- drop legacy employee row insertion
- compute summary from month grid
- update clock route to always write into a single grid

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685f174b94548321a4aaae6d8abfcc40