### PR TITLE
Fix log storage per employee and month detection

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,10 +58,10 @@ def ensure_current_month_table(name: str) -> None:
     now = dt.datetime.now(dt.timezone.utc).astimezone(dt.timezone(dt.timedelta(hours=0)))
     current_label = now.strftime("%B %Y")
 
-    first_cell = ws.acell("A1").value or ""
+    first_cell = (ws.acell("A1").value or "").strip()
     if first_cell != current_label:
         # if the sheet was created with the old format (no month label), add one
-        if first_cell.strip().lower() == "name":
+        if first_cell.lower() == "name":
             prev_month = (now - dt.timedelta(days=1)).strftime("%B %Y")
             ws.insert_rows([[]], row=1)
             ws.update("A1", prev_month)

--- a/static/script.js
+++ b/static/script.js
@@ -14,8 +14,12 @@ function getTodayKey() {
   return now.getFullYear() + '-' + mm + '-' + dd;
 }
 
+function storageKey() {
+  return 'attendanceLog_' + encodeURIComponent(employeeName) + '_' + getTodayKey();
+}
+
 function loadTodayLogs() {
-  let key = 'attendanceLog_' + getTodayKey();
+  let key = storageKey();
   let raw = localStorage.getItem(key);
   if (raw) {
     let logs = JSON.parse(raw);
@@ -28,7 +32,7 @@ function loadTodayLogs() {
 }
 
 function saveTodayLogs() {
-  let key = 'attendanceLog_' + getTodayKey();
+  let key = storageKey();
   localStorage.setItem(key, JSON.stringify(todayLogs));
 }
 


### PR DESCRIPTION
## Summary
- ensure month label comparison ignores stray spaces
- store per-employee logs separately in the browser

## Testing
- `python -m py_compile app.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_686a5f6a104c8321882acccd536a4ddd