### PR TITLE
Add cash, order and payout tracking

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -48,12 +48,19 @@
 
   <div id="tab-stats" class="tab-content">
     <div id="stats-content"></div>
+    <div id="payout-section">
+      <input type="number" id="payoutAmount" placeholder="Payout amount" />
+      <button onclick="recordPayout()">Record Payout</button>
+    </div>
+    <div id="payout-history"></div>
   </div>
 
   <div id="modalConfirm">
     <div class="modal-content">
       <p id="modalMsg"></p>
       <div class="modal-time" id="modalTime"></div>
+      <input type="number" id="inputCash" placeholder="Cash amount" style="display:none" />
+      <input type="number" id="inputOrders" placeholder="Order count" style="display:none" />
       <button onclick="confirmAction()">OK</button>
     </div>
   </div>

--- a/static/style.css
+++ b/static/style.css
@@ -92,6 +92,12 @@ h2 {
   max-width: 350px;
   margin: auto;
 }
+#modalConfirm input {
+  width: 80%;
+  padding: 6px;
+  margin-bottom: 10px;
+  font-size: 16px;
+}
 #modalConfirm p { font-size: 20px; margin: 0 0 18px 0; }
 #modalConfirm .modal-time { font-size: 17px; color: #007BFF; margin-bottom: 18px; }
 #modalConfirm button {
@@ -156,4 +162,25 @@ h2 {
 
 .sheet-month h4 {
   margin: 10px 0;
+}
+
+#payout-section {
+  margin-top: 20px;
+}
+#payout-section input {
+  padding: 6px;
+  margin-right: 8px;
+}
+#payout-history table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 10px;
+}
+#payout-history th, #payout-history td {
+  border: 1px solid #ccc;
+  padding: 4px;
+  text-align: center;
+}
+#payout-history th {
+  background: #f0f0f0;
 }


### PR DESCRIPTION
## Summary
- add new rows to employee sheet for cash amount, order count and payout
- support recording arbitrary values in Flask backend
- store cash/order values on clock-out and add payout endpoint
- extend frontend UI for cash, order, and payout inputs
- compute payout history and totals in stats tab

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686a69ff2e3c8321b53e601eaa1a22f3