### PR TITLE
Improve stats layout

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -49,21 +49,23 @@
   <div id="tab-stats" class="tab-content">
     <div id="stats-content"></div>
     <div id="period-cards"></div>
-    <div id="order-section">
-      <input type="number" id="orderInput" placeholder="Order number" />
-      <button onclick="recordOrder()">Add Order</button>
-    </div>
-    <div id="cash-section">
-      <input type="number" id="cashAmount" placeholder="Cash amount" />
-      <button onclick="recordCash()">Add Cash</button>
-    </div>
-    <div id="advance-section">
-      <input type="number" id="advanceAmount" placeholder="Advance amount" />
-      <button onclick="recordAdvance()">Record Advance</button>
-    </div>
-    <div id="payout-section">
-      <input type="number" id="payoutAmount" placeholder="Payout amount" />
-      <button onclick="recordPayout()">Record Payout</button>
+    <div class="stats-controls">
+      <div id="order-section">
+        <input type="number" id="orderInput" placeholder="Order number" />
+        <button class="stats-btn" onclick="recordOrder()">Add Order</button>
+      </div>
+      <div id="cash-section">
+        <input type="number" id="cashAmount" placeholder="Cash amount" />
+        <button class="stats-btn" onclick="recordCash()">Add Cash</button>
+      </div>
+      <div id="advance-section">
+        <input type="number" id="advanceAmount" placeholder="Advance amount" />
+        <button class="stats-btn" onclick="recordAdvance()">Record Advance</button>
+      </div>
+      <div id="payout-section">
+        <input type="number" id="payoutAmount" placeholder="Payout amount" />
+        <button class="stats-btn" onclick="recordPayout()">Record Payout</button>
+      </div>
     </div>
     <div id="payout-history"></div>
     <div id="order-history"></div>

--- a/static/style.css
+++ b/static/style.css
@@ -171,12 +171,30 @@ h2 {
   padding: 6px;
   margin-right: 8px;
 }
-#advance-section {
-  margin-top: 20px;
+
+#order-section,
+#cash-section,
+#advance-section,
+#payout-section {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 90%;
+  max-width: 500px;
+  padding: 10px 0;
 }
-#advance-section input {
+
+#order-section input,
+#cash-section input,
+#advance-section input,
+#payout-section input {
   padding: 6px;
   margin-right: 8px;
+  flex: 1;
+}
+
+#advance-section {
+  margin-top: 20px;
 }
 #period-cards {
   display: flex;
@@ -185,10 +203,31 @@ h2 {
   width: 100%;
   margin-top: 10px;
 }
+.stats-controls {
+  width: 90%;
+  max-width: 500px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.stats-btn {
+  background: #007BFF;
+  color: #fff;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 16px;
+}
 .period-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
   border: 1px solid #ccc;
   border-radius: 8px;
-  padding: 10px;
+  padding: 12px;
   background: #fff;
   box-shadow: 0 1px 3px #0002;
 }


### PR DESCRIPTION
## Summary
- style new stats control sections with flex layouts
- group order, cash, and advance inputs in a container
- add shared button class for stats actions
- tweak period card layout

## Testing
- `python -m py_compile app.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_686a7932b2b48321a8b5b404211b0ea4