### PR TITLE
Improve stats summary by half-month periods

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -66,8 +66,6 @@
       <button onclick="recordPayout()">Record Payout</button>
     </div>
     <div id="payout-history"></div>
-    <div id="order-history"></div>
-    <div id="cash-summary"></div>
   </div>
 
   <div id="modalConfirm">


### PR DESCRIPTION
## Summary
- simplify stats cards to show half-month periods
- compute worked/extra hours and cash totals with new rules
- remove unused order and cash summary elements from the page

## Testing
- `python3 -m py_compile app.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_686a7930bfac8321a80c7c070642a3a3