### PR TITLE
Add ability to clear local attendance logs

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -39,6 +39,9 @@
       <div class="log-section" id="break-log"></div>
       <div class="log-section" id="extra-log"></div>
     </div>
+    <div style="text-align:center;margin-top:10px;">
+      <button class="stats-btn" onclick="clearLocalLogs()">Clear Local Logs</button>
+    </div>
     <div id="msg"></div>
   </div>
 

--- a/static/script.js
+++ b/static/script.js
@@ -36,6 +36,16 @@ function saveTodayLogs() {
   localStorage.setItem(key, JSON.stringify(todayLogs));
 }
 
+// Remove today's logs from localStorage and reset in-memory state
+function clearLocalLogs() {
+  let key = storageKey();
+  localStorage.removeItem(key);
+  todayLogs = { main: [], break: [], extra: [] };
+  openPeriods = { main: null, break: null, extra: null };
+  document.getElementById('status').innerText = 'Status: Not Clocked In';
+  renderDayLog();
+}
+
 function getOpenPeriodsFromLogs(logs) {
   let open = { main: null, break: null, extra: null };
   ['main','break','extra'].forEach(cat => {


### PR DESCRIPTION
## Summary
- add `clearLocalLogs()` helper and reset state
- include button in Attendance tab to clear stored day logs

## Testing
- `python -m py_compile app.py config.py`

------
https://chatgpt.com/codex/tasks/task_e_686a826663588321a692191dd8e9de77