### PR TITLE
Add cache_discovery option to Sheets API client

### DIFF
--- a/app.py
+++ b/app.py
@@ -18,7 +18,12 @@ server = Flask(__name__, static_folder="static", static_url_path="/static")
 # --------------------------------------------------------------------
 # 2.  Google Sheets service
 # --------------------------------------------------------------------
-sheets_service = build("sheets", "v4", credentials=config.CREDENTIALS)
+sheets_service = build(
+    "sheets",
+    "v4",
+    credentials=config.CREDENTIALS,
+    cache_discovery=False,
+)
 sheet          = sheets_service.spreadsheets()
 
 # --------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- disable discovery caching in Sheets service client

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686a8263765c8321b08d135038ea9410