### PR TITLE
Improve sheet fetch error handling

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -256,14 +256,23 @@ function switchTab(tab) {
 
 function fetchSheetData() {
   fetch('/sheet_data?employee=' + encodeURIComponent(employeeName))
-    .then(r => r.json())
+    .then(r => {
+      if (!r.ok) {
+        return r.text().then(t => {
+          throw new Error(`HTTP ${r.status} ${t || r.statusText}`);
+        });
+      }
+      return r.json();
+    })
     .then(data => {
       sheetLoaded = true;
       renderSheetTable(data.values || []);
       renderStats(data.values || []);
     })
-    .catch(() => {
-      document.getElementById('sheet-table').innerText = 'Error loading data';
+    .catch(err => {
+      sheetLoaded = false;
+      document.getElementById('sheet-table').innerText =
+        'Error loading data: ' + err.message;
     });
 }
 


### PR DESCRIPTION
## Summary
- check `r.ok` before parsing sheet fetch response
- display status code or error text on failure
- reset `sheetLoaded` when fetching fails so the user can retry

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686a88720b248321b99eff302896aef2