### PR TITLE
Fix stats calculation and streamline stats UI

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -61,10 +61,6 @@
         <input type="number" id="cashAmount" placeholder="Cash amount" />
         <button class="stats-btn" onclick="recordCash()">Add Cash</button>
       </div>
-      <div id="advance-section">
-        <input type="number" id="advanceAmount" placeholder="Advance amount" />
-        <button class="stats-btn" onclick="recordAdvance()">Record Advance</button>
-      </div>
       <div id="payout-section">
         <input type="number" id="payoutAmount" placeholder="Payout amount" />
         <button class="stats-btn" onclick="recordPayout()">Record Payout</button>

--- a/static/style.css
+++ b/static/style.css
@@ -174,7 +174,6 @@ h2 {
 
 #order-section,
 #cash-section,
-#advance-section,
 #payout-section {
   display: flex;
   align-items: center;
@@ -186,16 +185,12 @@ h2 {
 
 #order-section input,
 #cash-section input,
-#advance-section input,
 #payout-section input {
   padding: 6px;
   margin-right: 8px;
   flex: 1;
 }
 
-#advance-section {
-  margin-top: 20px;
-}
 #period-cards {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- correct row offsets for stats calculations so totals show correctly
- remove duplicate fields in period cards
- drop advance input from stats controls

## Testing
- `python -m py_compile app.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_686aad1d14a8832198fed82ae037e119