### PR TITLE
Update stats tab UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,7 +51,7 @@ def ensure_employee_sheet(name: str) -> str:
             name, "(Out)", "(Duration)", "(Work Outcome)",
             "(Break Start)", "(Break End)", "(Break Outcome)",
             "(Extra Start)", "(Extra End)", "(Extra Outcome)",
-            "(Cash Amount)", "(Order Count)", "(Payout)", "(Advance)",
+            "(Avance)", "(Order Count)", "(Payment 15 jours)", "(Advance)",
         ]
         ws.update("A2:A15", [[lbl] for lbl in labels])
 
@@ -89,9 +89,9 @@ def ensure_current_month_table(name: str) -> None:
                 "(Extra Start)",
                 "(Extra End)",
                 "(Extra Outcome)",
-                "(Cash Amount)",
+                "(Avance)",
                 "(Order Count)",
-                "(Payout)",
+                "(Payment 15 jours)",
                 "(Advance)",
             ]
 

--- a/static/index.html
+++ b/static/index.html
@@ -50,21 +50,11 @@
   </div>
 
   <div id="tab-stats" class="tab-content">
-    <div id="stats-content"></div>
     <div id="period-cards"></div>
     <div class="stats-controls">
-      <div id="order-section">
-        <input type="number" id="orderInput" placeholder="Order number" />
-        <button class="stats-btn" onclick="recordOrder()">Add Order</button>
-      </div>
-      <div id="cash-section">
-        <input type="number" id="cashAmount" placeholder="Cash amount" />
-        <button class="stats-btn" onclick="recordCash()">Add Cash</button>
-      </div>
-      <div id="payout-section">
-        <input type="number" id="payoutAmount" placeholder="Payout amount" />
-        <button class="stats-btn" onclick="recordPayout()">Record Payout</button>
-      </div>
+      <button class="stats-btn" onclick="recordOrder()">Add Order</button>
+      <button class="stats-btn" onclick="recordCash()">Avance</button>
+      <button class="stats-btn" onclick="recordPayout()">Payment 15 jours</button>
     </div>
     <div id="payout-history"></div>
     <div id="order-history"></div>

--- a/static/script.js
+++ b/static/script.js
@@ -331,7 +331,6 @@ function parseTime(str) {
 
 function renderStats(values) {
   if (!Array.isArray(values) || !values.length || !Array.isArray(values[0])) {
-    document.getElementById('stats-content').innerText = 'No data';
     document.getElementById('period-cards').innerHTML = '';
     document.getElementById('payout-history').innerHTML = '';
     document.getElementById('order-history').innerText = '';
@@ -418,23 +417,14 @@ function renderStats(values) {
     }
   }
 
-  const summaryHtml =
-    `<div class="stats-summary">` +
-    `<h3>Summary</h3>` +
-    `<p><strong>Worked days:</strong> ${summary.worked}</p>` +
-    `<p><strong>Total hours:</strong> ${formatDuration(summary.minutes)}</p>` +
-    `<p><strong>Extra hours:</strong> ${formatDuration(summary.extra)}</p>` +
-    `<p><strong>Cash added:</strong> ${summary.cashAdd}</p>` +
-    `<p><strong>Cash taken:</strong> ${summary.cashTake}</p>` +
-    `<p><strong>Orders:</strong> ${summary.orders.join(', ')}</p>` +
-    `</div>`;
-  document.getElementById('stats-content').innerHTML = summaryHtml;
+  // No summary section at top of stats tab
 
   const currentCards = [];
   const archivedCards = [];
   periods.forEach(p => {
     const card = `<div class="period-card ${p.payout ? 'archived' : 'current'}">` +
       `<div class="range">${p.start} – ${p.end}</div>` +
+      `<div>Worked days: ${p.worked}</div>` +
       `<div>Extra hours: ${formatDuration(p.extra)}</div>` +
       `<div>Cash added: ${p.cashAdd}</div>` +
       `<div>Cash taken: ${p.cashTake}</div>` +
@@ -461,7 +451,7 @@ function renderStats(values) {
 }
 
 function recordPayout() {
-  const amt = document.getElementById('payoutAmount').value;
+  const amt = prompt('Enter payout amount:');
   if (!amt) return;
   fetch('/payout', {
     method: 'POST',
@@ -480,7 +470,7 @@ function recordPayout() {
 }
 
 function recordOrder() {
-  const num = document.getElementById('orderInput').value;
+  const num = prompt('Enter order number:');
   if (!num) return;
   fetch('/order', {
     method: 'POST',
@@ -499,7 +489,7 @@ function recordOrder() {
 }
 
 function recordCash() {
-  const amt = document.getElementById('cashAmount').value;
+  const amt = prompt('Enter avance amount:');
   if (!amt) return;
   fetch('/cash', {
     method: 'POST',

--- a/static/style.css
+++ b/static/style.css
@@ -164,32 +164,6 @@ h2 {
   margin: 10px 0;
 }
 
-#payout-section {
-  margin-top: 20px;
-}
-#payout-section input {
-  padding: 6px;
-  margin-right: 8px;
-}
-
-#order-section,
-#cash-section,
-#payout-section {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  width: 90%;
-  max-width: 500px;
-  padding: 10px 0;
-}
-
-#order-section input,
-#cash-section input,
-#payout-section input {
-  padding: 6px;
-  margin-right: 8px;
-  flex: 1;
-}
 
 #period-cards {
   display: flex;
@@ -201,8 +175,8 @@ h2 {
 .stats-controls {
   width: 90%;
   max-width: 500px;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
   gap: 10px;
   margin-top: 20px;
 }
@@ -215,23 +189,7 @@ h2 {
   border-radius: 6px;
   cursor: pointer;
   font-size: 16px;
-}
-.stats-summary {
-  width: 90%;
-  max-width: 500px;
-  background: #fff;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px #0002;
-  padding: 12px 16px;
-  margin-bottom: 16px;
-}
-.stats-summary h3 {
-  margin-top: 0;
-  margin-bottom: 8px;
-  color: #007BFF;
-}
-.stats-summary p {
-  margin: 4px 0;
+  width: 100%;
 }
 .period-card {
   display: flex;


### PR DESCRIPTION
## Summary
- change sheet labels for cash and payout
- rework stats tab layout and remove summary
- align stat buttons and use prompt popups

## Testing
- `python -m py_compile app.py`
- `node -c static/script.js > /dev/null && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_686ae9207b048321b2c7793e71727300