### PR TITLE
Update style and rename stats renderer

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -267,7 +267,7 @@ function fetchSheetData() {
     .then(data => {
       sheetLoaded = true;
       renderSheetTable(data.values || []);
-      renderStats(data.values || []);
+      renderPayments(data.values || []);
     })
     .catch(err => {
       sheetLoaded = false;
@@ -329,7 +329,7 @@ function parseTime(str) {
   return parts[0] * 60 + parts[1];
 }
 
-function renderStats(values) {
+function renderPayments(values) {
   if (!Array.isArray(values) || !values.length || !Array.isArray(values[0])) {
     document.getElementById('period-cards').innerHTML = '';
     document.getElementById('payout-history').innerHTML = '';

--- a/static/style.css
+++ b/static/style.css
@@ -207,7 +207,7 @@ h2 {
   border-left: 4px solid #9e9e9e;
 }
 .period-card.current {
-  border-left: 4px solid #007BFF;
+  border-left: 4px solid #4CAF50;
 }
 .period-card .range {
   font-weight: bold;


### PR DESCRIPTION
## Summary
- tweak the style for current periods
- rename `renderStats` function to `renderPayments`

## Testing
- `python -m py_compile app.py`
- `python -m py_compile config.py`

------
https://chatgpt.com/codex/tasks/task_e_686afc12a4488321acad16db8def5141