### PR TITLE
Add performance tab and rename stats

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -14,7 +14,8 @@
   <div class="tabs">
     <button class="tab-button active" data-tab="attendance">Attendance</button>
     <button class="tab-button" data-tab="sheet">Sheet</button>
-    <button class="tab-button" data-tab="stats">Stats</button>
+    <button class="tab-button" data-tab="payments">Payments</button>
+    <button class="tab-button" data-tab="performance">Performance</button>
   </div>
 
   <div id="tab-attendance" class="tab-content active">
@@ -49,7 +50,7 @@
     <div id="sheet-table"></div>
   </div>
 
-  <div id="tab-stats" class="tab-content">
+  <div id="tab-payments" class="tab-content">
     <div id="period-cards"></div>
     <div class="stats-controls">
       <button class="stats-btn" onclick="recordOrder()">Add Order</button>
@@ -60,6 +61,8 @@
     <div id="order-history"></div>
     <div id="cash-summary"></div>
   </div>
+
+  <div id="tab-performance" class="tab-content"></div>
 
   <div id="modalConfirm">
     <div class="modal-content">


### PR DESCRIPTION
## Summary
- rename Stats tab to Payments and add a Performance tab
- load sheet data when Payments or Performance is selected
- rename `renderStats` to `renderPayments`
- implement new `renderPerformance` summary function

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686afc14c5e883219874b740616e507d