### PR TITLE
Add payments tab and daily stats

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -15,6 +15,7 @@
     <button class="tab-button active" data-tab="attendance">Attendance</button>
     <button class="tab-button" data-tab="sheet">Sheet</button>
     <button class="tab-button" data-tab="stats">Stats</button>
+    <button class="tab-button" data-tab="payments">Payments</button>
     <button class="tab-button" data-tab="performance">Performance</button>
   </div>
 
@@ -51,6 +52,10 @@
   </div>
 
   <div id="tab-stats" class="tab-content">
+    <div id="stats-summary"></div>
+  </div>
+
+  <div id="tab-payments" class="tab-content">
     <div id="period-cards"></div>
     <div class="stats-controls">
       <button class="stats-btn" onclick="recordOrder()">Add Order</button>

--- a/static/script.js
+++ b/static/script.js
@@ -44,6 +44,7 @@ function clearLocalLogs() {
   openPeriods = { main: null, break: null, extra: null };
   document.getElementById('status').innerText = 'Status: Not Clocked In';
   renderDayLog();
+  renderStats();
 }
 
 function getOpenPeriodsFromLogs(logs) {
@@ -69,6 +70,7 @@ window.onload = function() {
   document.getElementById('employeeName').innerText = '👤 ' + employeeName;
   startClock();
   renderDayLog();
+  renderStats();
 };
 
 function startClock() {
@@ -196,6 +198,7 @@ function renderDayLog() {
   document.getElementById('break-log').innerHTML = renderSection(todayLogs.break, 'break');
   document.getElementById('extra-log').innerHTML = renderSection(todayLogs.extra, 'extra');
   saveTodayLogs();
+  renderStats();
 }
 
 function getCategoryTotalMinutes(category, now = null, ignoreOpen = false) {
@@ -235,6 +238,18 @@ function formatDuration(mins) {
   return (h ? `${h}h ` : '') + (m ? `${m}min` : (h ? '' : '0 min'));
 }
 
+function renderStats() {
+  const main = getCategoryTotalMinutes('main');
+  const brk = getCategoryTotalMinutes('break');
+  const extra = getCategoryTotalMinutes('extra');
+  const net = main - brk + extra;
+  document.getElementById('stats-summary').innerHTML =
+    `<div>Main: ${formatDuration(main)}</div>` +
+    `<div>Break: ${formatDuration(brk)}</div>` +
+    `<div>Extra: ${formatDuration(extra)}</div>` +
+    `<div>Net: ${formatDuration(net)}</div>`;
+}
+
 // ===== Tabs & Sheet Data =====
 document.querySelectorAll('.tab-button').forEach(btn => {
   btn.addEventListener('click', () => switchTab(btn.dataset.tab));
@@ -249,7 +264,7 @@ function switchTab(tab) {
   document.querySelectorAll('.tab-content').forEach(div => {
     div.classList.toggle('active', div.id === 'tab-' + tab);
   });
-  if ((tab === 'sheet' || tab === 'stats' || tab === 'performance') && !sheetLoaded) {
+  if ((tab === 'sheet' || tab === 'payments' || tab === 'performance') && !sheetLoaded) {
     fetchSheetData();
   }
 }


### PR DESCRIPTION
## Summary
- include a Payments tab in the UI
- move payment controls to new tab
- show basic daily totals in a Stats tab
- keep sheet data fetch for Payments and Performance tabs

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686b00ff870083219fe2dda5cfbc872c