### PR TITLE
Improve payment UI and add data caching

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -14,7 +14,6 @@
   <div class="tabs">
     <button class="tab-button active" data-tab="attendance">Attendance</button>
     <button class="tab-button" data-tab="sheet">Sheet</button>
-    <button class="tab-button" data-tab="stats">Stats</button>
     <button class="tab-button" data-tab="payments">Payments</button>
     <button class="tab-button" data-tab="performance">Performance</button>
   </div>
@@ -51,9 +50,6 @@
     <div id="sheet-table"></div>
   </div>
 
-  <div id="tab-stats" class="tab-content">
-    <div id="stats-summary"></div>
-  </div>
 
   <div id="tab-payments" class="tab-content">
     <div id="period-cards"></div>
@@ -62,9 +58,6 @@
       <button class="stats-btn" onclick="recordCash()">Avance</button>
       <button class="stats-btn" onclick="recordPayout()">Payment 15 jours</button>
     </div>
-    <div id="payout-history"></div>
-    <div id="order-history"></div>
-    <div id="cash-summary"></div>
   </div>
 
   <div id="tab-performance" class="tab-content">

--- a/static/script.js
+++ b/static/script.js
@@ -243,7 +243,9 @@ function renderDayStats() {
   const brk = getCategoryTotalMinutes('break');
   const extra = getCategoryTotalMinutes('extra');
   const net = main - brk + extra;
-  document.getElementById('stats-summary').innerHTML =
+  const el = document.getElementById('stats-summary');
+  if (!el) return;
+  el.innerHTML =
     `<div>Main: ${formatDuration(main)}</div>` +
     `<div>Break: ${formatDuration(brk)}</div>` +
     `<div>Extra: ${formatDuration(extra)}</div>` +
@@ -264,7 +266,7 @@ function switchTab(tab) {
   document.querySelectorAll('.tab-content').forEach(div => {
     div.classList.toggle('active', div.id === 'tab-' + tab);
   });
-  if ((tab === 'sheet' || tab === 'stats') && !sheetLoaded) {
+  if ((tab === 'sheet' || tab === 'payments' || tab === 'performance') && !sheetLoaded) {
     fetchSheetData();
   }
 }
@@ -356,9 +358,6 @@ function parseNumberList(str) {
 function renderStats(values) {
   if (!Array.isArray(values) || !values.length || !Array.isArray(values[0])) {
     document.getElementById('period-cards').innerHTML = '';
-    document.getElementById('payout-history').innerHTML = '';
-    document.getElementById('order-history').innerText = '';
-    document.getElementById('cash-summary').innerText = '';
     return;
   }
 
@@ -468,18 +467,7 @@ function renderStats(values) {
   });
   document.getElementById('period-cards').innerHTML = currentCards.join('') + archivedCards.join('');
 
-  let histHtml = '';
-  const paid = periods.filter(p => p.payout);
-  if (paid.length) {
-    histHtml += '<h4>Payout History</h4><table><thead><tr><th>Start</th><th>End</th><th>Amount</th></tr></thead><tbody>';
-    paid.forEach(p => {
-      histHtml += `<tr><td>${p.start}</td><td>${p.end}</td><td>${p.payout}</td></tr>`;
-    });
-    histHtml += '</tbody></table>';
-  }
-  document.getElementById('payout-history').innerHTML = histHtml;
-  document.getElementById('order-history').innerText = 'Orders: ' + totalOrdersList.join(', ');
-  document.getElementById('cash-summary').innerText = 'Total cash: ' + totalCash;
+  // paid periods already moved to the bottom above
 }
 
 function recordPayout() {

--- a/static/style.css
+++ b/static/style.css
@@ -214,22 +214,6 @@ h2 {
   margin-bottom: 4px;
   color: #007BFF;
 }
-#payout-history table {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 10px;
-}
-#payout-history th, #payout-history td {
-  border: 1px solid #ccc;
-  padding: 6px;
-  text-align: center;
-}
-#payout-history th {
-  background: #f0f0f0;
-}
-#payout-history tr:nth-child(even) {
-  background-color: #f9f9f9;
-}
 
 #performance-score {
   margin-top: 10px;


### PR DESCRIPTION
## Summary
- speed up `/sheet_data` requests with in-memory cache
- remove "Stats" tab and payout history section from the UI
- show only period cards in Payments tab and hide history text
- fetch sheet data when opening payments/performance tabs

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686bbf7c235883219643bf50a4695f72