### PR TITLE
Add month schedule APIs

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -272,8 +272,13 @@ function switchTab(tab) {
   }
 }
 
-function fetchSheetData() {
-  fetch('/sheet_data?employee=' + encodeURIComponent(employeeName))
+function fetchSheetData(month) {
+  const now = month ? new Date(month) : new Date();
+  const mStr = (typeof month === 'string') ? month :
+    now.getFullYear() + '-' + String(now.getMonth() + 1).padStart(2, '0');
+  const url = '/month_schedule?employee=' + encodeURIComponent(employeeName) +
+              '&month=' + encodeURIComponent(mStr);
+  fetch(url)
     .then(r => {
       if (!r.ok) {
         return r.text().then(t => {


### PR DESCRIPTION
## Summary
- add helper functions for month/archived schedules
- expose `/month_schedule` and `/archive` endpoints
- update `/sheet_data` to use new helpers
- use `/month_schedule` from the frontend

## Testing
- `python -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872f935ea8c832198ca0cdb7ff2e3d5