### PR TITLE
Add admin dashboard features

### DIFF
--- a/static/admin.html
+++ b/static/admin.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Admin Dashboard</title>
+  <link rel="stylesheet" href="/static/style.css" />
+</head>
+<body>
+  <h2>Admin Dashboard</h2>
+  <div id="employee-list"></div>
+  <div id="sheet-table"></div>
+  <script src="/static/admin.js"></script>
+</body>
+</html>

--- a/static/admin.js
+++ b/static/admin.js
@@ -1,0 +1,49 @@
+function renderSheetTable(values) {
+  if (!Array.isArray(values) || !values.length) {
+    document.getElementById('sheet-table').innerText = 'No data';
+    return;
+  }
+  let html = '<table><tbody>';
+  values.forEach(row => {
+    html += '<tr>' + row.map(c => `<td>${c || ''}</td>`).join('') + '</tr>';
+  });
+  html += '</tbody></table>';
+  document.getElementById('sheet-table').innerHTML = html;
+}
+
+function loadEmployee(name) {
+  fetch('/admin/attendance/' + encodeURIComponent(name))
+    .then(r => r.json())
+    .then(data => {
+      renderSheetTable(data.values || []);
+    })
+    .catch(err => {
+      document.getElementById('sheet-table').innerText = 'Error: ' + err.message;
+    });
+}
+
+function loadEmployees() {
+  fetch('/admin/employees')
+    .then(r => r.json())
+    .then(data => {
+      const list = document.getElementById('employee-list');
+      if (!Array.isArray(data.employees)) {
+        list.innerText = 'No employees';
+        return;
+      }
+      let html = '<ul>';
+      data.employees.forEach(emp => {
+        html += `<li><button class="emp-btn" data-emp="${emp}">${emp}</button></li>`;
+      });
+      html += '</ul>';
+      list.innerHTML = html;
+      document.querySelectorAll('.emp-btn').forEach(btn => {
+        btn.addEventListener('click', () => loadEmployee(btn.dataset.emp));
+      });
+    })
+    .catch(err => {
+      document.getElementById('employee-list').innerText = 'Error: ' + err.message;
+    });
+}
+
+window.onload = loadEmployees;

--- a/static/style.css
+++ b/static/style.css
@@ -224,3 +224,24 @@ h2 {
 
 #performance-score.good { color: #4CAF50; }
 #performance-score.bad { color: #f44336; }
+
+/* Admin dashboard */
+#employee-list {
+  margin: 20px 0;
+}
+#employee-list ul {
+  list-style: none;
+  padding: 0;
+}
+.emp-btn {
+  padding: 6px 12px;
+  margin-bottom: 6px;
+  border: none;
+  background: #e0e0e0;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 16px;
+}
+.emp-btn:hover {
+  background: #d0d0d0;
+}


### PR DESCRIPTION
## Summary
- add admin endpoints `/admin`, `/admin/employees`, `/admin/attendance/<employee>`
- create simple admin dashboard HTML and JS
- style admin dashboard in stylesheet

## Testing
- `python -m py_compile app.py`
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6872f93748288321a4aa416ba6ef1a7f