### PR TITLE
Add SQLAlchemy helper for attendance tables

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,19 +1,34 @@
 import os
-from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine
+from sqlalchemy import create_engine, MetaData, Table, Column, Integer, String, Date
+
+# Database URL from env or default to local SQLite file
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///attendance.db")
+engine = create_engine(DATABASE_URL)
+metadata = MetaData()
 
 
-def get_engine() -> Engine:
-    """Return a SQLAlchemy engine using DATABASE_URL env-var."""
-    url = os.getenv("DATABASE_URL")
-    if not url:
-        raise RuntimeError("\u274c  DATABASE_URL env-var not set!")
+def ensure_employee_table(name: str) -> Table:
+    """Return SQLAlchemy Table for `name`, creating it if missing."""
+    table_name = f"attendance_{name.lower()}"
+    # Reflect to load existing tables
+    metadata.reflect(bind=engine)
 
-    engine = create_engine(
-        url,
-        pool_size=5,
-        max_overflow=10,
-        pool_pre_ping=True,
-    )
-    return engine
-
+    if table_name not in metadata.tables:
+        Table(
+            table_name,
+            metadata,
+            Column("id", Integer, primary_key=True),
+            Column("date", Date, nullable=False, unique=True),
+            Column("clock_in", String(5)),
+            Column("clock_out", String(5)),
+            Column("break_start", String(5)),
+            Column("break_end", String(5)),
+            Column("extra_start", String(5)),
+            Column("extra_end", String(5)),
+            Column("extra_hours", String(5)),
+            Column("cash", Integer, default=0),
+            Column("advance", Integer, default=0),
+            Column("orders", Integer, default=0),
+        )
+        metadata.create_all(bind=engine, tables=[metadata.tables[table_name]])
+    return metadata.tables[table_name]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,4 @@ google-auth-oauthlib==1.2.0
 google-api-python-client==2.130.0
 gspread==6.1.1
 # any **real** version: 6.0.0–6.2.1 all work
-psycopg2-binary==2.9.9
-SQLAlchemy==2.0.30
+SQLAlchemy==2.0.29


### PR DESCRIPTION
## Summary
- simplify database layer using SQLAlchemy
- default to a local SQLite file when `DATABASE_URL` isn't defined
- drop `psycopg2-binary` dependency and pin SQLAlchemy 2.0.29

## Testing
- `python -m py_compile db.py app.py`

------
https://chatgpt.com/codex/tasks/task_e_6872fe7ac8dc8321962c4191b9f75959