### PR TITLE
Add React frontend with Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Attendance App
 
-A lightweight Flask application for tracking employee attendance. Each employee has their own sheet/tab inside a Google Sheets spreadsheet. Employees can check in, start breaks, log work outcomes, and more, all via a simple web UI.
+A lightweight Flask application for tracking employee attendance. Each employee
+has their own sheet/tab inside a Google Sheets spreadsheet. Employees can check
+in, start breaks, log work outcomes, and more, all via a simple web UI.
 
 ## Required Environment Variables
 
@@ -11,6 +13,8 @@ The app pulls configuration from a few environment variables:
 - `DATABASE_URL` – Postgres connection string used by `db.get_engine()`.
 
 ## Running Locally
+
+### Backend
 
 1. Install Python dependencies:
 
@@ -34,13 +38,29 @@ The app pulls configuration from a few environment variables:
 
 Visit `http://localhost:8080/?employee=YourName` to interact with the app.
 
+### Frontend
+
+The React frontend lives in the `frontend/` directory. To start the Vite dev
+server:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The app will be available at `http://localhost:3000`.
+
 ## Deploying
 
-The `deploy.sh` script builds a Docker image and deploys it to Cloud Run. Edit the variables at the top of the script, then run:
+The `deploy.sh` script builds a Docker image and deploys it to Cloud Run. Edit the
+variables at the top of the script, then run:
 
 ```bash
 chmod +x deploy.sh
 ./deploy.sh
 ```
 
-The script uploads the service account key to Secret Manager and sets the `GOOGLE_SHEET_ID`, `GCP_SA_B64`, and `DATABASE_URL` variables for the Cloud Run service.
+The script uploads the service account key to Secret Manager and sets the
+`GOOGLE_SHEET_ID`, `GCP_SA_B64`, and `DATABASE_URL` variables for the Cloud Run
+service.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Attendance</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "attendance-frontend",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "vite": "^4.3.9",
+    "autoprefixer": "^10.4.14",
+    "postcss": "^8.4.27",
+    "tailwindcss": "^3.3.2",
+    "@vitejs/plugin-react": "^4.1.0"
+  }
+}

--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,10 @@
+import AttendancePad from './AttendancePad'
+
+export default function App() {
+  return (
+    <div className="flex flex-col items-center p-4 gap-4">
+      <h2 className="text-2xl font-bold">Employee Attendance</h2>
+      <AttendancePad />
+    </div>
+  )
+}

--- a/frontend/src/AttendancePad.jsx
+++ b/frontend/src/AttendancePad.jsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+
+export default function AttendancePad() {
+  const [employee, setEmployee] = useState('')
+  const [time, setTime] = useState(new Date())
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    setEmployee(params.get('employee') || params.get('driver') || '')
+  }, [])
+
+  useEffect(() => {
+    const id = setInterval(() => setTime(new Date()), 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  const send = (action) => {
+    if (!employee) return
+    fetch('/attendance', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ employee, action })
+    }).catch(console.error)
+  }
+
+  return (
+    <div className="flex flex-col items-center w-full max-w-md gap-6">
+      <div className="text-lg font-semibold" data-testid="name">{employee}</div>
+      <div>{time.toLocaleString()}</div>
+      <div className="grid grid-cols-2 gap-4 w-full">
+        <button className="bg-green-600 text-white rounded-lg p-6 text-xl" onClick={() => send('clockin')}>✅ Clock In</button>
+        <button className="bg-red-500 text-white rounded-lg p-6 text-xl" onClick={() => send('clockout')}>🕔 Clock Out</button>
+      </div>
+      <div className="grid grid-cols-2 gap-4 w-full">
+        <button className="bg-orange-500 text-white rounded-lg p-6 text-xl" onClick={() => send('startbreak')}>🛑 Start Break</button>
+        <button className="bg-blue-600 text-white rounded-lg p-6 text-xl" onClick={() => send('endbreak')}>✅ End Break</button>
+      </div>
+      <div className="grid grid-cols-2 gap-4 w-full">
+        <button className="bg-purple-700 text-white rounded-lg p-6 text-xl" onClick={() => send('startextra')}>➕ Start Extra Hours</button>
+        <button className="bg-fuchsia-700 text-white rounded-lg p-6 text-xl" onClick={() => send('endextra')}>🛑 End Extra Hours</button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+})


### PR DESCRIPTION
## Summary
- add a React 18 + Vite front-end in `frontend/`
- configure Tailwind via PostCSS
- document how to run the new UI

## Testing
- `python -m py_compile app.py`
- `npm run dev` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_687389c9251c83218e4f0e815f442945