### PR TITLE
Add FastAPI events API

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,3 @@
+from .main import app
+
+__all__ = ["app"]

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+from datetime import datetime, timezone
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException, Depends, Query
+from sqlalchemy import select, update, delete, func, and_
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .models import Event, AsyncSessionLocal, init_models
+
+app = FastAPI()
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    await init_models()
+
+async def get_session() -> AsyncSession:
+    async with AsyncSessionLocal() as session:
+        yield session
+
+@app.post("/events", response_model=dict)
+async def create_event(
+    employee_id: str,
+    kind: str,
+    timestamp: datetime,
+    session: AsyncSession = Depends(get_session),
+):
+    event = Event(
+        employee_id=employee_id,
+        kind=kind,
+        timestamp=timestamp,
+    )
+    session.add(event)
+    await session.commit()
+    await session.refresh(event)
+    return {"id": event.id}
+
+@app.get("/events", response_model=List[dict])
+async def list_events(
+    employee_id: Optional[str] = Query(None),
+    month: Optional[str] = Query(None, pattern=r"^\d{4}-\d{2}$"),
+    session: AsyncSession = Depends(get_session),
+):
+    stmt = select(Event)
+    conditions = []
+    if employee_id:
+        conditions.append(Event.employee_id == employee_id)
+    if month:
+        year, m = map(int, month.split("-"))
+        start = datetime(year, m, 1, tzinfo=timezone.utc)
+        if m == 12:
+            end = datetime(year + 1, 1, 1, tzinfo=timezone.utc)
+        else:
+            end = datetime(year, m + 1, 1, tzinfo=timezone.utc)
+        conditions.append(and_(Event.timestamp >= start, Event.timestamp < end))
+    if conditions:
+        stmt = stmt.where(*conditions)
+    stmt = stmt.order_by(Event.timestamp)
+    result = await session.execute(stmt)
+    events = [
+        {
+            "id": e.id,
+            "employee_id": e.employee_id,
+            "kind": e.kind,
+            "timestamp": e.timestamp.isoformat(),
+            "created_at": e.created_at.isoformat() if e.created_at else None,
+            "updated_at": e.updated_at.isoformat() if e.updated_at else None,
+        }
+        for e in result.scalars()
+    ]
+    return events
+
+@app.patch("/events/{event_id}", response_model=dict)
+async def update_event(
+    event_id: int,
+    employee_id: Optional[str] = None,
+    kind: Optional[str] = None,
+    timestamp: Optional[datetime] = None,
+    session: AsyncSession = Depends(get_session),
+):
+    stmt = select(Event).where(Event.id == event_id)
+    result = await session.execute(stmt)
+    event = result.scalar_one_or_none()
+    if not event:
+        raise HTTPException(status_code=404, detail="Event not found")
+    if employee_id is not None:
+        event.employee_id = employee_id
+    if kind is not None:
+        event.kind = kind
+    if timestamp is not None:
+        event.timestamp = timestamp
+    await session.commit()
+    await session.refresh(event)
+    return {"id": event.id}
+
+@app.delete("/events/{event_id}", response_model=dict)
+async def delete_event(event_id: int, session: AsyncSession = Depends(get_session)):
+    stmt = delete(Event).where(Event.id == event_id)
+    result = await session.execute(stmt)
+    if result.rowcount == 0:
+        raise HTTPException(status_code=404, detail="Event not found")
+    await session.commit()
+    return {"ok": True}
+
+# Expose app for uvicorn/gunicorn
+__all__ = ["app"]

--- a/api/models.py
+++ b/api/models.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+import os
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import String, Integer, DateTime
+from sqlalchemy.ext.asyncio import AsyncAttrs, create_async_engine, async_sessionmaker, AsyncSession
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+if not DATABASE_URL:
+    raise RuntimeError("DATABASE_URL environment variable not set")
+
+# convert sync postgres url to async if needed
+if DATABASE_URL.startswith("postgresql://") and not DATABASE_URL.startswith("postgresql+asyncpg://"):
+    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+asyncpg://", 1)
+
+engine = create_async_engine(DATABASE_URL, echo=False)
+AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+class Base(AsyncAttrs, DeclarativeBase):
+    pass
+
+class Event(Base):
+    __tablename__ = "events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    employee_id: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    kind: Mapped[str] = mapped_column(String(50), nullable=False)
+    timestamp: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow)
+
+async def init_models() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ google-api-python-client==2.130.0
 gspread==6.1.1
 # any **real** version: 6.0.0–6.2.1 all work
 SQLAlchemy==2.0.29
+fastapi==0.111.0
+uvicorn==0.29.0
+asyncpg==0.29.0


### PR DESCRIPTION
## Summary
- add async `api` package with FastAPI app
- define async SQLAlchemy `Event` model and initialization
- implement CRUD routes for events
- update requirements with FastAPI, uvicorn and asyncpg

## Testing
- `python -m pip install -r requirements.txt` *(fails: Tunnel connection failed)*
- `python -m py_compile api/main.py api/models.py api/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68739541c53083218a18bab197d4966c