### PR TITLE
Install psycopg2 driver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ SQLAlchemy==2.0.29
 fastapi==0.111.0
 uvicorn==0.29.0
 asyncpg==0.29.0
+psycopg2-binary==2.9.9


### PR DESCRIPTION
## Summary
- add `psycopg2-binary` to requirements to satisfy `psycopg2` import

## Testing
- `pip install -r requirements.txt` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687396ff1b4c8321a47827a489e9f121