### PR TITLE
Add FastAPI tests and coverage setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,3 +78,16 @@ To undo the most recent migration:
 ```bash
 alembic downgrade -1
 ```
+
+## Running Tests
+
+The test suite spins up a temporary Postgres 15 container using `testcontainers`.
+Install the extra testing dependencies and run `pytest` with coverage:
+
+```bash
+pip install -r requirements.txt
+pip install pytest pytest-asyncio pytest-cov testcontainers[postgres] httpx
+pytest --cov
+```
+
+Coverage should report at least 80%.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+import os
+import importlib
+import asyncio
+import pytest
+from testcontainers.postgres import PostgresContainer
+from httpx import AsyncClient
+
+@pytest.fixture(scope="session")
+def event_loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+@pytest.fixture(scope="session")
+async def client():
+    with PostgresContainer("postgres:15") as postgres:
+        url = postgres.get_connection_url()
+        async_url = url.replace("postgresql://", "postgresql+asyncpg://")
+        os.environ["DATABASE_URL"] = async_url
+
+        import api.models
+        import api.main
+        importlib.reload(api.models)
+        importlib.reload(api.main)
+
+        from api.models import init_models
+        from api.main import app
+
+        await init_models()
+        async with AsyncClient(app=app, base_url="http://test") as ac:
+            yield ac

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = --cov=api --cov-report=term-missing
+asyncio_mode = auto

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,43 @@
+from datetime import datetime, timezone
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_event_lifecycle(client):
+    ts = datetime.now(timezone.utc).isoformat()
+
+    # create
+    resp = await client.post(
+        "/events", params={"employee_id": "alice", "kind": "in", "timestamp": ts}
+    )
+    assert resp.status_code == 200
+    event_id = resp.json()["id"]
+
+    # list
+    resp = await client.get("/events")
+    assert resp.status_code == 200
+    events = resp.json()
+    assert any(e["id"] == event_id for e in events)
+
+    # update
+    resp = await client.patch(f"/events/{event_id}", params={"kind": "out"})
+    assert resp.status_code == 200
+    assert resp.json()["id"] == event_id
+
+    # delete
+    resp = await client.delete(f"/events/{event_id}")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+    # confirm deletion
+    resp = await client.get("/events")
+    assert all(e["id"] != event_id for e in resp.json())
+
+
+@pytest.mark.asyncio
+async def test_not_found(client):
+    resp = await client.patch("/events/9999", params={"kind": "out"})
+    assert resp.status_code == 404
+    resp = await client.delete("/events/9999")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- add pytest config and fixtures for starting a Postgres 15 container
- hit FastAPI endpoints using AsyncClient
- document how to run tests locally with coverage

## Testing
- `pytest --cov` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_68739784ba388321a6b6567caad1f6ba