### PR TITLE
Add body model to update_event

### DIFF
--- a/frontend/src/AdminDashboard.jsx
+++ b/frontend/src/AdminDashboard.jsx
@@ -26,8 +26,9 @@ export default function AdminDashboard() {
   })
 
   const mutation = useMutation({
-    mutationFn: async ({ id, timestamp }) => {
-      await axios.patch(`/events/${id}`, { timestamp })
+    mutationFn: async (body) => {
+      const { id, ...data } = body
+      await axios.patch(`/events/${id}`, data)
     },
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ['events', monthStr] })

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,9 +21,13 @@ async def test_event_lifecycle(client):
     assert any(e["id"] == event_id for e in events)
 
     # update
-    resp = await client.patch(f"/events/{event_id}", params={"kind": "out"})
+    resp = await client.patch(f"/events/{event_id}", json={"kind": "out"})
     assert resp.status_code == 200
     assert resp.json()["id"] == event_id
+
+    resp = await client.get("/events")
+    updated = [e for e in resp.json() if e["id"] == event_id][0]
+    assert updated["kind"] == "out"
 
     # delete
     resp = await client.delete(f"/events/{event_id}")
@@ -37,7 +41,7 @@ async def test_event_lifecycle(client):
 
 @pytest.mark.asyncio
 async def test_not_found(client):
-    resp = await client.patch("/events/9999", params={"kind": "out"})
+    resp = await client.patch("/events/9999", json={"kind": "out"})
     assert resp.status_code == 404
     resp = await client.delete("/events/9999")
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- accept an `EventUpdate` body when updating an event
- adjust AdminDashboard mutation to send the body object directly
- patch tests to use JSON bodies and verify updates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_6873a5284d908321b1412f2393da073c