### PR TITLE
Add dev requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ The test suite spins up a temporary Postgres 15 container using `testcontainers`
 Install the extra testing dependencies and run `pytest` with coverage:
 
 ```bash
-pip install -r requirements.txt
-pip install pytest pytest-asyncio pytest-cov testcontainers[postgres] httpx
+pip install -r requirements.txt -r requirements-dev.txt
+pip install httpx
 pytest --cov
 ```
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest
+pytest-asyncio
+pytest-cov
+testcontainers[postgres]
+httpx


### PR DESCRIPTION
## Summary
- add `requirements-dev.txt`
- reference dev requirements file in README test instructions

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails: could not fetch packages)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_6873abac7a608321a4ba2e522aaa8aa4