### PR TITLE
Fix missing asgiref dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ fastapi==0.111.0
 uvicorn==0.29.0
 asyncpg==0.29.0
 psycopg2-binary==2.9.9
+asgiref==3.8.1


### PR DESCRIPTION
## Summary
- add `asgiref` to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_6873b39bd2448321a9bfea2b1c02eaf6