### PR TITLE
Build frontend automatically

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
-# ---------- 1. base image ----------
+# ---------- 1. build frontend ----------
+FROM node:18 AS frontend-build
+WORKDIR /app/frontend
+COPY frontend/package.json ./
+RUN npm install
+COPY frontend/ ./
+RUN npm run build
+
+# ---------- 2. backend base image ----------
 FROM python:3.11-slim
 
 # ---------- 2. env & deps ----------
@@ -13,6 +21,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # ---------- 3. copy source ----------
 COPY . .
+COPY --from=frontend-build /app/frontend/dist ./frontend/dist
 
 # ---------- 4. non-root user for Cloud Run ----------
 RUN adduser --disabled-password --gecos '' appuser \

--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ npm run build   # production build
 
 During development the Vite dev server serves the app on `http://localhost:5173`
 and API requests are sent to the backend running on `http://localhost:8080`.
-When deploying, the backend will serve the compiled files from
-`frontend/dist` so the frontend and API share the same URL.
+When deploying, the Dockerfile builds the frontend and copies the compiled
+files from `frontend/dist` into the final image so the backend can serve them
+directly. No manual npm commands are needed in the deployment pipeline.
 
 ## Deploying
 


### PR DESCRIPTION
## Summary
- build the React frontend during Docker build using a separate Node stage
- copy built assets into the final image
- clarify in README that the Dockerfile builds the frontend so Cloud Run deployments don't need manual npm commands

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_6873d8649e1c8321a71304ad771299ff