### PR TITLE
Fix dependency name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ uvicorn==0.29.0
 asyncpg==0.29.0
 psycopg2-binary==2.9.9
 asgiref==3.8.1
-supabase-py==2.4.2
+supabase==2.4.2


### PR DESCRIPTION
## Summary
- update `supabase-py` dependency name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_6873dd02586483219edcf914bae1c31d