### PR TITLE
Update env docs and deploy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,18 @@
 # Attendance App
 
 A lightweight Flask application for tracking employee attendance backed by a
-Postgres database hosted on Supabase. Employees can check in, start breaks, log
+Postgres database. You can point `DATABASE_URL` at any Postgres host, including
+Supabase which is used purely as a managed Postgres provider. Employees can check in, start breaks, log
 work outcomes and more, all via a simple web UI.
 
 ## Required Environment Variables
 
-Configure the backend with your Supabase credentials using these variables:
+Set up the backend with a Postgres connection string:
 
-- `SUPABASE_URL` – URL of your Supabase project.
-- `SUPABASE_KEY` – service API key for the project.
-- `DATABASE_URL` – optional Postgres connection string overriding
-  `SUPABASE_URL`.
+- `DATABASE_URL` – Postgres connection string. This can point to any
+  reachable database instance and may reference Supabase's Postgres service.
+- `SUPABASE_URL` – optional shorthand containing just the Supabase project URL
+  if you prefer not to embed credentials in `DATABASE_URL`.
 
 ## Running Locally
 
@@ -26,9 +27,8 @@ Configure the backend with your Supabase credentials using these variables:
 2. Export the environment variables:
 
    ```bash
-   export SUPABASE_URL=https://your-project.supabase.co
-   export SUPABASE_KEY=your_service_key
-   export DATABASE_URL=postgresql://user:pass@localhost/dbname  # optional
+   export DATABASE_URL=postgresql://user:pass@localhost/dbname
+   export SUPABASE_URL=https://your-project.supabase.co  # optional convenience
    ```
 
 3. Start the server:
@@ -67,8 +67,8 @@ chmod +x deploy.sh
 ./deploy.sh
 ```
 
-The script sets the `SUPABASE_URL`, `SUPABASE_KEY` and `DATABASE_URL`
-environment variables for the Cloud Run service.
+The script sets the `DATABASE_URL` (and optionally `SUPABASE_URL`) environment
+variables for the Cloud Run service.
 The script prints the service URL when deployment completes. Use that
 `https://<your-cloud-run-url>` to access the app. The FastAPI API will be
 reachable under `/api` on the deployed URL.
@@ -99,3 +99,4 @@ pytest --cov
 ```
 
 Coverage should report at least 80%.
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -26,10 +26,9 @@ REPO="apps"                                     # Artifact Registry repo name
 IMAGE_NAME="attendance-app"
 SERVICE_ACCOUNT="attendance-run-sa@${PROJECT_ID}.iam.gserviceaccount.com"
 
-# Supabase connection details
+# Supabase connection URL (optional convenience)
 SUPABASE_URL="https://your-project.supabase.co"
-SUPABASE_KEY="YOUR_SUPABASE_SERVICE_KEY"
-# Optional Postgres connection string overriding SUPABASE_URL
+# Postgres connection string; can point to Supabase
 DATABASE_URL=""
 # ══════════════════════════════════════════════════════════════════
 
@@ -63,7 +62,7 @@ gcloud run deploy "$APP_NAME" \
   --platform managed \
   --allow-unauthenticated \
   --service-account "$SERVICE_ACCOUNT" \
-  --set-env-vars "SUPABASE_URL=${SUPABASE_URL},SUPABASE_KEY=${SUPABASE_KEY},DATABASE_URL=${DATABASE_URL}" \
+  --set-env-vars "DATABASE_URL=${DATABASE_URL},SUPABASE_URL=${SUPABASE_URL}" \
   --port 8080
 
 # ── Show service URL ─────────────────────────────────────────────

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ uvicorn==0.29.0
 asyncpg==0.29.0
 psycopg2-binary==2.9.9
 asgiref==3.8.1
-supabase==2.4.2


### PR DESCRIPTION
## Summary
- remove unused `supabase` python dependency
- clarify that the app only relies on Postgres, mentioning Supabase merely as a host
- drop `SUPABASE_KEY` references from the docs and deploy script
- streamline environment variable instructions

## Testing
- `pytest --cov` *(fails: ModuleNotFoundError: No module named 'testcontainers')*
- `python app.py` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_6873e0ebb8bc8321b4f841fb87700509