### PR TITLE
Fix DSN parsing for psycopg2

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,7 +39,10 @@ if not DATABASE_URL:
 
 def db_connect():
     """Return a new database connection."""
-    return psycopg2.connect(DATABASE_URL)
+    url = DATABASE_URL
+    if url.startswith("postgresql+asyncpg://"):
+        url = url.replace("postgresql+asyncpg://", "postgresql://", 1)
+    return psycopg2.connect(url)
 
 
 def table_name(employee: str) -> str:


### PR DESCRIPTION
## Summary
- handle `postgresql+asyncpg://` URLs in Flask database helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_6873e85f260483218bfc8d6af88c3a7a