### PR TITLE
Add SPA catch-all route

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ Set up the backend with a Postgres connection string:
 Visit `https://<your-cloud-run-url>/?employee=YourName` to interact with the app.
 The FastAPI API is mounted under `/api`, e.g. `https://<your-cloud-run-url>/api/events`.
 
+All other GET routes that don't begin with `/api`, `/attendance`, `/payout` or
+`/healthz` return the compiled React app from `frontend/dist/index.html`. This
+allows bookmarking URLs like `/admin-dashboard` or `/employee-dashboard` when
+deploying the single page app.
+
 ### Frontend
 
 The React frontend lives in the `frontend/` directory.

--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import logging
 import time
 import psycopg2
 from psycopg2 import sql
-from flask import Flask, request, jsonify
+from flask import Flask, request, jsonify, abort
 from werkzeug.middleware.dispatcher import DispatcherMiddleware
 from asgi_to_wsgi import AsgiToWsgi
 
@@ -183,3 +183,11 @@ def payout():
 @server.route("/healthz")
 def health():
     return "OK", 200
+
+
+# Serve React app for any unmatched GET route
+@server.route("/<path:path>", methods=["GET"])
+def spa_catch_all(path: str):
+    if path.startswith(("api", "attendance", "payout", "healthz")):
+        abort(404)
+    return index()

--- a/frontend/dist/index.html
+++ b/frontend/dist/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Attendance SPA</title>
+  </head>
+  <body>
+    <div id="root">Attendance SPA</div>
+  </body>
+</html>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,0 +1,30 @@
+import os
+import pathlib
+import pytest
+
+os.environ.setdefault("DATABASE_URL", "postgresql://user:pass@localhost/db")
+
+from app import server  # noqa: E402
+
+@pytest.fixture()
+def client():
+    server.testing = True
+    with server.test_client() as c:
+        yield c
+
+INDEX_FILE = pathlib.Path(__file__).resolve().parents[1] / "frontend" / "dist" / "index.html"
+EXPECTED_CONTENT = INDEX_FILE.read_bytes()
+
+
+def test_admin_dashboard(client):
+    resp = client.get("/admin-dashboard")
+    assert resp.status_code == 200
+    assert resp.mimetype == "text/html"
+    assert resp.data == EXPECTED_CONTENT
+
+
+def test_employee_dashboard(client):
+    resp = client.get("/employee-dashboard")
+    assert resp.status_code == 200
+    assert resp.mimetype == "text/html"
+    assert resp.data == EXPECTED_CONTENT


### PR DESCRIPTION
## Summary
- serve React index.html for all non-API GET routes
- include a placeholder React build for tests
- test GET `/admin-dashboard` and `/employee-dashboard`
- document behaviour in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_6873f1af1fc0832199ebe466b6e371c6