### PR TITLE
Add monthly and period summary views

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,6 +1,8 @@
 import AttendancePad from './AttendancePad'
 import AdminDashboard from './AdminDashboard'
 import EmployeeDashboard from './EmployeeDashboard'
+import MonthlySheets from './MonthlySheets'
+import PeriodSummary from './PeriodSummary'
 import { motion, useReducedMotion } from 'framer-motion'
 
 export default function App() {
@@ -11,6 +13,12 @@ export default function App() {
   }
   if (path.startsWith('/employee-dashboard')) {
     return <EmployeeDashboard />
+  }
+  if (path.startsWith('/monthly-sheets')) {
+    return <MonthlySheets />
+  }
+  if (path.startsWith('/period-summary')) {
+    return <PeriodSummary />
   }
   return (
     <motion.div

--- a/frontend/src/MonthlySheets.jsx
+++ b/frontend/src/MonthlySheets.jsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+
+export default function MonthlySheets() {
+  const months = [
+    { label: 'July 2025', rows: sampleRows() },
+    { label: 'June 2025', rows: sampleRows() },
+    { label: 'May 2025', rows: sampleRows() },
+  ]
+  const [open, setOpen] = useState(null)
+  return (
+    <div className="p-4 space-y-4 overflow-auto h-full scrollbar-thin scrollbar-thumb-sapphire/50">
+      <div className="sticky top-0 z-10">
+        <div className="card">
+          <div className="bg-sapphire text-center -mx-6 -mt-6 rounded-t-xl py-2 text-white font-semibold">
+            {months[0].label}
+          </div>
+          <Table rows={months[0].rows} />
+        </div>
+      </div>
+      {months.slice(1).map((m, idx) => (
+        <div key={m.label} className="card">
+          <button
+            onClick={() => setOpen(open === idx ? null : idx)}
+            className="w-full text-left font-semibold mb-2"
+          >
+            {m.label}
+          </button>
+          {open === idx && <Table rows={m.rows} />}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function Table({ rows }) {
+  return (
+    <table className="w-full text-sm">
+      <thead className="bg-white/10">
+        <tr>
+          <th className="p-1">Date</th>
+          <th className="p-1">In</th>
+          <th className="p-1">Out</th>
+          <th className="p-1">Break Start</th>
+          <th className="p-1">Break End</th>
+          <th className="p-1">Extra Start</th>
+          <th className="p-1">Extra End</th>
+          <th className="p-1">Total Hrs</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((r, i) => (
+          <tr
+            key={r.date}
+            className={
+              (i % 2 ? 'bg-white/5' : '') +
+              (r.weekend ? ' bg-violet/10' : '') +
+              (r.holiday ? ' bg-amber-200/20' : '')
+            }
+          >
+            <td className="p-1 text-center whitespace-nowrap">{r.date}</td>
+            <td className="p-1 text-center">{r.in}</td>
+            <td className="p-1 text-center">{r.out}</td>
+            <td className="p-1 text-center">{r.breakStart}</td>
+            <td className="p-1 text-center">{r.breakEnd}</td>
+            <td className="p-1 text-center">{r.extraStart}</td>
+            <td className="p-1 text-center">{r.extraEnd}</td>
+            <td className="p-1 text-center">{r.total}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+function sampleRows() {
+  return [
+    {
+      date: '2025-07-01',
+      in: '09:00',
+      out: '17:00',
+      breakStart: '12:00',
+      breakEnd: '13:00',
+      extraStart: '',
+      extraEnd: '',
+      total: '8',
+      weekend: false,
+      holiday: false,
+    },
+    {
+      date: '2025-07-05',
+      in: '09:00',
+      out: '17:00',
+      breakStart: '12:00',
+      breakEnd: '13:00',
+      extraStart: '',
+      extraEnd: '',
+      total: '8',
+      weekend: true,
+      holiday: false,
+    },
+    {
+      date: '2025-07-07',
+      in: '09:00',
+      out: '17:00',
+      breakStart: '12:00',
+      breakEnd: '13:00',
+      extraStart: '',
+      extraEnd: '',
+      total: '8',
+      weekend: false,
+      holiday: true,
+    },
+  ]
+}

--- a/frontend/src/PeriodSummary.jsx
+++ b/frontend/src/PeriodSummary.jsx
@@ -1,0 +1,67 @@
+export default function PeriodSummary() {
+  const periods = [
+    {
+      title: '1 \u2013 15',
+      workedDays: 10,
+      hours: 80,
+      payout: 0,
+      advance: 0,
+      balance: 0,
+      orders: 4,
+      ordersTotal: 200,
+    },
+    {
+      title: '16 \u2013 31',
+      workedDays: 12,
+      hours: 96,
+      payout: 0,
+      advance: 0,
+      balance: 0,
+      orders: 6,
+      ordersTotal: 300,
+    },
+  ]
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="grid md:grid-cols-2 gap-4">
+        {periods.map((p) => (
+          <div key={p.title} className="card space-y-2">
+            <div className="bg-sapphire text-white rounded-full px-3 py-1 inline-block font-semibold">
+              {p.title}
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              <div>Worked Days</div>
+              <div className="text-right font-semibold">{p.workedDays}</div>
+              <div>Total Hours</div>
+              <div className="text-right font-semibold">{p.hours}</div>
+              <div>Payout (DH)</div>
+              <div className="text-right font-semibold">{p.payout}</div>
+              <div>Advances (DH)</div>
+              <div className="text-right font-semibold">{p.advance}</div>
+              <div>Balance</div>
+              <div className="text-right font-semibold">{p.balance}</div>
+              <div>Orders Count</div>
+              <div className="text-right font-semibold">{p.orders}</div>
+              <div>Orders Total</div>
+              <div className="text-right font-semibold">{p.ordersTotal}</div>
+            </div>
+          </div>
+        ))}
+        <div className="card space-y-2">
+          <div className="font-semibold mb-1">Add Advance \ud83d\udcb8</div>
+          <input type="number" className="w-full rounded bg-white/10 p-1" placeholder="Amount" />
+          <input type="date" className="w-full rounded bg-white/10 p-1" />
+        </div>
+        <div className="card space-y-2">
+          <div className="font-semibold mb-1">Record Order \ud83d\udcdf</div>
+          <input type="text" className="w-full rounded bg-white/10 p-1" placeholder="Order ID" />
+          <input type="number" className="w-full rounded bg-white/10 p-1" placeholder="Total" />
+        </div>
+      </div>
+      <div className="bg-white/20 text-center font-semibold py-2 rounded-xl">
+        Orders Total: {periods.reduce((s,p)=>s+p.ordersTotal,0)} | Balance: {periods.reduce((s,p)=>s+p.balance,0)}
+      </div>
+    </div>
+  )
+}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -28,3 +28,17 @@ def test_employee_dashboard(client):
     assert resp.status_code == 200
     assert resp.mimetype == "text/html"
     assert resp.data == EXPECTED_CONTENT
+
+
+def test_monthly_sheets(client):
+    resp = client.get("/monthly-sheets")
+    assert resp.status_code == 200
+    assert resp.mimetype == "text/html"
+    assert resp.data == EXPECTED_CONTENT
+
+
+def test_period_summary(client):
+    resp = client.get("/period-summary")
+    assert resp.status_code == 200
+    assert resp.mimetype == "text/html"
+    assert resp.data == EXPECTED_CONTENT


### PR DESCRIPTION
## Summary
- create MonthlySheets page with accordion months and zebra tables
- create PeriodSummary page summarizing two pay periods
- route new pages in `App.jsx`
- ensure SPA routes exist via tests

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pip install httpx` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_68743f4f3ac08321a8c338bac2cccf35