### PR TITLE
Add performance tab and navigation improvements

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,32 +3,36 @@ import AdminDashboard from './AdminDashboard'
 import EmployeeDashboard from './EmployeeDashboard'
 import MonthlySheets from './MonthlySheets'
 import PeriodSummary from './PeriodSummary'
-import { motion, useReducedMotion } from 'framer-motion'
+import Performance from './Performance'
+import NavBar from './components/NavBar'
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 
 export default function App() {
   const shouldReduce = useReducedMotion()
   const path = window.location.pathname
-  if (path.startsWith('/admin-dashboard')) {
-    return <AdminDashboard />
-  }
-  if (path.startsWith('/employee-dashboard')) {
-    return <EmployeeDashboard />
-  }
-  if (path.startsWith('/monthly-sheets')) {
-    return <MonthlySheets />
-  }
-  if (path.startsWith('/period-summary')) {
-    return <PeriodSummary />
-  }
+  if (path.startsWith('/admin-dashboard')) return <AdminDashboard />
+  if (path.startsWith('/employee-dashboard')) return <EmployeeDashboard />
+
+  let Page = AttendancePad
+  if (path.startsWith('/monthly-sheets')) Page = MonthlySheets
+  else if (path.startsWith('/period-summary')) Page = PeriodSummary
+  else if (path.startsWith('/performance')) Page = Performance
+
   return (
-    <motion.div
-      initial={shouldReduce ? false : { opacity: 0 }}
-      animate={shouldReduce ? {} : { opacity: 1 }}
-      transition={{ duration: 0.3 }}
-      className="flex flex-col items-center p-4 gap-4 min-h-screen"
-    >
-      <h2 className="text-2xl font-bold">Employee Attendance</h2>
-      <AttendancePad />
-    </motion.div>
+    <>
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={path}
+          initial={shouldReduce ? false : { opacity: 0, x: 50 }}
+          animate={shouldReduce ? {} : { opacity: 1, x: 0 }}
+          exit={shouldReduce ? {} : { opacity: 0, x: -50 }}
+          transition={{ duration: 0.3 }}
+          className="pt-4 pb-16 min-h-screen"
+        >
+          <Page />
+        </motion.div>
+      </AnimatePresence>
+      <NavBar path={path} />
+    </>
   )
 }

--- a/frontend/src/Performance.jsx
+++ b/frontend/src/Performance.jsx
@@ -1,0 +1,86 @@
+import { Line } from 'react-chartjs-2'
+import { Chart, LineElement, CategoryScale, LinearScale, PointElement, Tooltip } from 'chart.js'
+import { motion } from 'framer-motion'
+
+Chart.register(LineElement, CategoryScale, LinearScale, PointElement, Tooltip)
+
+export default function Performance() {
+  const totalScore = 82
+  const metrics = [
+    { label: 'AM punctuality', icon: '⏰', value: 88 },
+    { label: 'PM punctuality', icon: '🌅', value: 80 },
+    { label: 'Break discipline', icon: '☕', value: 70 },
+    { label: 'Extra hours', icon: '💪', value: 95 },
+    { label: 'Consistency', icon: '📆', value: 78 },
+    { label: 'App usage accuracy', icon: '✅', value: 90 },
+  ]
+
+  const verdict = (v) => {
+    if (v >= 90) return 'Excellent'
+    if (v >= 75) return 'Good'
+    if (v >= 50) return 'Fair'
+    return 'Poor'
+  }
+
+  const labels = Array.from({ length: 30 }, (_, i) => `d${i + 1}`)
+  const scores = labels.map(() => 60 + Math.round(Math.random() * 40))
+  const lineData = {
+    labels,
+    datasets: [
+      {
+        data: scores,
+        borderColor: '#3b82f6',
+        backgroundColor: 'rgba(59,130,246,0.2)',
+        tension: 0.3,
+      },
+    ],
+  }
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: 50 }}
+      animate={{ opacity: 1, x: 0 }}
+      exit={{ opacity: 0, x: -50 }}
+      transition={{ duration: 0.3 }}
+      className="p-4 space-y-6"
+    >
+      <div className="flex justify-center">
+        <div className="relative w-40 h-40">
+          <div
+            className="absolute inset-0 rounded-full"
+            style={{
+              background: `conic-gradient(crimson ${totalScore}%, lime ${totalScore}% 100%)`,
+            }}
+          />
+          <div className="absolute inset-1 bg-background rounded-full flex items-center justify-center text-3xl font-bold">
+            {totalScore}%
+          </div>
+        </div>
+      </div>
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
+        {metrics.map((m) => (
+          <div
+            key={m.label}
+            className="rounded-full px-3 py-1 text-sm font-semibold flex items-center justify-between"
+            style={{
+              background:
+                m.value >= 75
+                  ? 'rgba(34,197,94,0.3)'
+                  : m.value >= 50
+                  ? 'rgba(250,204,21,0.3)'
+                  : 'rgba(239,68,68,0.3)',
+            }}
+          >
+            <span>
+              {m.icon} {m.label}
+            </span>
+            <span>
+              {m.value}% {verdict(m.value)}
+            </span>
+          </div>
+        ))}
+      </div>
+      <Line data={lineData} />
+    </motion.div>
+  )
+}

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -1,0 +1,32 @@
+import { motion } from 'framer-motion'
+
+const items = [
+  { path: '/', label: 'Daily', icon: '📅' },
+  { path: '/monthly-sheets', label: 'Monthly', icon: '🗓️' },
+  { path: '/period-summary', label: 'Periods', icon: '📊' },
+  { path: '/performance', label: 'Performance', icon: '🚀' },
+]
+
+export default function NavBar({ path }) {
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 bg-white/10 backdrop-blur-md px-2 py-1 flex justify-around text-sm">
+      {items.map((it) => (
+        <a
+          key={it.path}
+          href={it.path}
+          className="relative flex flex-col items-center px-2 py-1"
+        >
+          <span>{it.icon}</span>
+          <span>{it.label}</span>
+          {path.startsWith(it.path) && (
+            <motion.span
+              layoutId="nav-indicator"
+              className="absolute -bottom-1 left-1/2 h-1 w-8 -translate-x-1/2 rounded-full bg-sapphire"
+            />
+          )}
+        </a>
+      ))}
+    </nav>
+  )
+}
+

--- a/frontend/src/components/Toast.jsx
+++ b/frontend/src/components/Toast.jsx
@@ -12,21 +12,27 @@ export function ToastProvider({ children }) {
     setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 3000)
   }, [])
 
+  const icons = {
+    success: '✅',
+    error: '❌',
+  }
+
   return (
     <ToastContext.Provider value={addToast}>
       {children}
-      <div className="fixed top-4 right-4 space-y-2 z-50">
+      <div className="fixed bottom-4 left-1/2 -translate-x-1/2 space-y-2 z-50">
         <AnimatePresence>
           {toasts.map((toast) => (
             <motion.div
               key={toast.id}
-              initial={{ opacity: 0, y: -10 }}
+              initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -10 }}
+              exit={{ opacity: 0, y: 10 }}
               transition={{ duration: 0.2 }}
-              className={`rounded-md px-4 py-2 shadow text-white ${toast.type === 'error' ? 'bg-red-600' : 'bg-green-600'}`}
+              className={`rounded-full px-4 py-2 shadow text-white flex items-center gap-2 ${toast.type === 'error' ? 'bg-red-600' : 'bg-green-600'}`}
             >
-              {toast.message}
+              <span>{icons[toast.type] || 'ℹ️'}</span>
+              <span>{toast.message}</span>
             </motion.div>
           ))}
         </AnimatePresence>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -12,6 +12,8 @@
   --color-coral: #f87171;
   --color-sapphire: #3b82f6;
   --color-violet: #8b5cf6;
+  --motion-curve: cubic-bezier(0.4, 0, 0.2, 1);
+  --motion-duration: 200ms;
 }
 
 [data-theme='dark'] {
@@ -31,7 +33,8 @@ body {
 }
 
 .btn {
-  @apply relative overflow-hidden rounded-xl shadow-lg text-white font-semibold h-24 flex flex-col items-center justify-center transition-all active:translate-y-[3px];
+  @apply relative overflow-hidden rounded-xl shadow-lg text-white font-semibold h-24 flex flex-col items-center justify-center;
+  transition: all var(--motion-duration) var(--motion-curve);
 }
 
 .btn-emerald {
@@ -59,7 +62,7 @@ body {
 .table-hover tbody tr:hover {
   background-color: rgba(255, 255, 255, 0.05);
   transform: translateX(4px);
-  transition: all 200ms;
+  transition: all var(--motion-duration) var(--motion-curve);
 }
 
 .ripple {
@@ -67,7 +70,7 @@ body {
   border-radius: 9999px;
   background: rgba(255, 255, 255, 0.4);
   transform: scale(0);
-  animation: ripple 200ms ease-out;
+  animation: ripple var(--motion-duration) var(--motion-curve);
   pointer-events: none;
 }
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -42,3 +42,10 @@ def test_period_summary(client):
     assert resp.status_code == 200
     assert resp.mimetype == "text/html"
     assert resp.data == EXPECTED_CONTENT
+
+
+def test_performance(client):
+    resp = client.get("/performance")
+    assert resp.status_code == 200
+    assert resp.mimetype == "text/html"
+    assert resp.data == EXPECTED_CONTENT


### PR DESCRIPTION
## Summary
- add animated bottom nav bar with indicator
- implement new Performance page with gauge, metrics chips and line chart
- unify transitions and ripple timing in CSS
- reposition toasts with emoji feedback
- serve `/performance` route in tests

## Testing
- `pip install -q -r requirements.txt -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_687440f2eaa88321aa0d91436a0c5019