### PR TITLE
Fix blank SPA by serving /assets URLs

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,6 +21,11 @@ server = Flask(
     __name__, static_folder=dist_path, static_url_path="/static"
 )
 
+# Map the original Vite /assets URLs to our /static path
+@server.route("/assets/<path:filename>")
+def assets(filename: str):
+    return server.send_static_file(os.path.join("assets", filename))
+
 # Mount FastAPI under /api using ASGI -> WSGI adapter
 try:
     from api.main import app as fastapi_app


### PR DESCRIPTION
## Summary
- patch `app.py` to handle requests to `/assets/<filename>`
  so the SPA can access Vite-built JS/CSS when `static_url_path` is `/static`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_68744a1df43883219aeac6de67eda4a7