### PR TITLE
Preserve employee context in UI

### DIFF
--- a/frontend/src/MonthlySheets.jsx
+++ b/frontend/src/MonthlySheets.jsx
@@ -1,6 +1,12 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 export default function MonthlySheets() {
+  const [employee, setEmployee] = useState('')
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    setEmployee(params.get('employee') || params.get('driver') || '')
+  }, [])
+
   const months = [
     { label: 'July 2025', rows: sampleRows() },
     { label: 'June 2025', rows: sampleRows() },
@@ -9,6 +15,7 @@ export default function MonthlySheets() {
   const [open, setOpen] = useState(null)
   return (
     <div className="p-4 space-y-4 overflow-auto h-full scrollbar-thin scrollbar-thumb-sapphire/50">
+      {employee && <h2 className="text-xl font-bold">{employee}</h2>}
       <div className="sticky top-0 z-10">
         <div className="card">
           <div className="bg-sapphire text-center -mx-6 -mt-6 rounded-t-xl py-2 text-white font-semibold">

--- a/frontend/src/Performance.jsx
+++ b/frontend/src/Performance.jsx
@@ -1,10 +1,17 @@
 import { Line } from 'react-chartjs-2'
 import { Chart, LineElement, CategoryScale, LinearScale, PointElement, Tooltip } from 'chart.js'
 import { motion } from 'framer-motion'
+import { useEffect, useState } from 'react'
 
 Chart.register(LineElement, CategoryScale, LinearScale, PointElement, Tooltip)
 
 export default function Performance() {
+  const [employee, setEmployee] = useState('')
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    setEmployee(params.get('employee') || params.get('driver') || '')
+  }, [])
+
   const totalScore = 82
   const metrics = [
     { label: 'AM punctuality', icon: '⏰', value: 88 },
@@ -44,6 +51,7 @@ export default function Performance() {
       transition={{ duration: 0.3 }}
       className="p-4 space-y-6"
     >
+      {employee && <h2 className="text-xl font-bold">{employee}</h2>}
       <div className="flex justify-center">
         <div className="relative w-40 h-40">
           <div

--- a/frontend/src/PeriodSummary.jsx
+++ b/frontend/src/PeriodSummary.jsx
@@ -1,4 +1,11 @@
+import { useEffect, useState } from 'react'
+
 export default function PeriodSummary() {
+  const [employee, setEmployee] = useState('')
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    setEmployee(params.get('employee') || params.get('driver') || '')
+  }, [])
   const periods = [
     {
       title: '1 \u2013 15',
@@ -24,6 +31,7 @@ export default function PeriodSummary() {
 
   return (
     <div className="p-4 space-y-4">
+      {employee && <h2 className="text-xl font-bold">{employee}</h2>}
       <div className="grid md:grid-cols-2 gap-4">
         {periods.map((p) => (
           <div key={p.title} className="card space-y-2">

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -8,12 +8,15 @@ const items = [
 ]
 
 export default function NavBar({ path }) {
+  const params = new URLSearchParams(window.location.search)
+  const employee = params.get('employee') || params.get('driver') || ''
+  const query = employee ? `?employee=${employee}` : ''
   return (
     <nav className="fixed bottom-0 left-0 right-0 bg-white/10 backdrop-blur-md px-2 py-1 flex justify-around text-sm">
       {items.map((it) => (
         <a
           key={it.path}
-          href={it.path}
+          href={it.path + query}
           className="relative flex flex-col items-center px-2 py-1"
         >
           <span>{it.icon}</span>


### PR DESCRIPTION
## Summary
- keep employee parameter when navigating between tabs
- show employee name in MonthlySheets, PeriodSummary and Performance pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_68745495ea6083218d7e8203e3f7a94f