### PR TITLE
Fix advance/order UI update and add logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -146,6 +146,7 @@ def record_value(employee: str, label: str, date: dt.date, value: str):
             ).format(table=sql.Identifier(tbl), col=sql.Identifier(col))
             cur.execute(query, (date, str(value)))
         conn.commit()
+    logger.info("Recorded %s for %s on %s: %s", label, employee, date, value)
     return True, "OK"
 
 # --------------------------------------------------------------------

--- a/frontend/src/PeriodSummary.jsx
+++ b/frontend/src/PeriodSummary.jsx
@@ -41,6 +41,18 @@ export default function PeriodSummary() {
     if (!advance) return
     try {
       await axios.post('/advance', { employee, amount: advance, date: advanceDate })
+      setMonths((prev) =>
+        prev.map((m) => {
+          if (!advanceDate.startsWith(m.monthStr)) return m
+          const idx = Number(advanceDate.slice(-2)) <= 15 ? 0 : 1
+          const periods = m.periods.slice()
+          const p = { ...periods[idx] }
+          p.advance = Number(p.advance) + Number(advance)
+          p.balance = p.payout - p.advance
+          periods[idx] = p
+          return { ...m, periods }
+        }),
+      )
       setAdvance('')
     } catch {
       /* ignore */
@@ -51,6 +63,18 @@ export default function PeriodSummary() {
     if (!orderId || !orderTotal) return
     try {
       await axios.post('/record-order', { employee, order_id: orderId, total: orderTotal, date: orderDate })
+      setMonths((prev) =>
+        prev.map((m) => {
+          if (!orderDate.startsWith(m.monthStr)) return m
+          const idx = Number(orderDate.slice(-2)) <= 15 ? 0 : 1
+          const periods = m.periods.slice()
+          const p = { ...periods[idx] }
+          p.orders += 1
+          p.ordersTotal = Number(p.ordersTotal) + Number(orderTotal)
+          periods[idx] = p
+          return { ...m, periods }
+        }),
+      )
       setOrderId('')
       setOrderTotal('')
     } catch {


### PR DESCRIPTION
## Summary
- log advance/order saves on backend
- update PeriodSummary frontend so newly saved advances and orders update the UI immediately

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_687570d9c0dc8321b7769578db4400a8