### PR TITLE
Fix PeriodSummary syntax

### DIFF
--- a/frontend/src/PeriodSummary.jsx
+++ b/frontend/src/PeriodSummary.jsx
@@ -208,7 +208,7 @@ export default function PeriodSummary() {
                     </div>
                   </div>
                 )
-              })() )}
+                })()}
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- fix JSX syntax in `PeriodSummary.jsx`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_68759ed0c1f48321b8e7e79fcd19a76a