### PR TITLE
Add devcontainer setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.11-slim
+
+# Install Node.js 18
+RUN apt-get update \
+    && apt-get install -y curl gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get install -y nodejs \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace/attendance-app
+
+COPY requirements.txt requirements.txt
+COPY requirements-dev.txt requirements-dev.txt
+RUN pip install --no-cache-dir -r requirements.txt -r requirements-dev.txt
+
+# Install frontend dependencies
+COPY frontend/package.json frontend/package.json
+RUN npm install --prefix frontend
+
+CMD ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+    "name": "Attendance App",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "workspaceFolder": "/workspace/attendance-app"
+}

--- a/README.md
+++ b/README.md
@@ -63,6 +63,11 @@ When deploying, the Dockerfile builds the frontend and copies the compiled
 files from `frontend/dist` into the final image so the backend can serve them
 directly. No manual npm commands are needed in the deployment pipeline.
 
+
+## Development container
+
+Codex launches this repository inside a dev container with Python and Node dependencies already installed. You can start working immediately without running `pip` or `npm` commands.
+
 ## Deploying
 
 The `deploy.sh` script builds a Docker image and deploys it to Cloud Run. Edit the


### PR DESCRIPTION
## Summary
- add Dockerfile for devcontainer
- configure devcontainer JSON
- document devcontainer usage in README

## Testing
- `pytest --cov` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_6875a45e862c8321a5a2fb55317dd722