### PR TITLE
Fix JSX invocation error

### DIFF
--- a/frontend/src/PeriodSummary.jsx
+++ b/frontend/src/PeriodSummary.jsx
@@ -141,8 +141,9 @@ export default function PeriodSummary() {
                   ))}
                 </div>
               </div>
-              {m.periods[activePeriod[idx] || 0] && (() => {
+              {(() => {
                 const p = m.periods[activePeriod[idx] || 0]
+                if (!p) return null
                 return (
                   <div className="space-y-4 accordion-bg rounded-xl p-2">
                     <KPIRows data={p} />


### PR DESCRIPTION
## Summary
- resolve JSX syntax error in `PeriodSummary.jsx` by simplifying IIFE check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_6875a498f768832185a81adb07ffce41