### PR TITLE
Enhance monthly view layout

### DIFF
--- a/frontend/src/MonthlySheets.jsx
+++ b/frontend/src/MonthlySheets.jsx
@@ -43,19 +43,32 @@ export default function MonthlySheets() {
             <div className="bg-sapphire text-center -mx-6 -mt-6 rounded-t-xl py-2 text-white font-semibold">
               {months[0].label}
             </div>
-            <Table rows={months[0].rows || []} />
+            {/* desktop table */}
+            <div className="hidden sm:block">
+              <Table rows={months[0].rows || []} />
+            </div>
+            {/* mobile cards */}
+            <div className="sm:hidden">
+              <DayCards rows={months[0].rows || []} />
+            </div>
           </div>
         </div>
       )}
       {months.slice(1).map((m, idx) => (
-        <div key={m.label} className="card">
+        <div key={m.label} className="card bg-white/5">
           <button
             onClick={() => setOpen(open === idx ? null : idx)}
-            className="w-full text-left font-semibold mb-2"
+            className="w-full text-center font-semibold mb-2 flex justify-center"
           >
+            <span className="mr-1">📁</span>
             {m.label}
+            <span className="ml-1">{open === idx ? '▲' : '▼'}</span>
           </button>
-          {open === idx && <Table rows={m.rows || []} />}
+          {open === idx && (
+            <div>
+              <DayCards rows={m.rows || []} />
+            </div>
+          )}
         </div>
       ))}
     </div>
@@ -63,19 +76,21 @@ export default function MonthlySheets() {
 }
 
 function Table({ rows }) {
+  const daysWorked = rows.filter(r => r.in || r.out).length
+  const extraHours = rows.reduce((s, r) => s + (parseFloat(r.extraTotal) || 0), 0)
   return (
     <div className="overflow-auto">
       <table className="w-full text-xs sm:text-sm table-fixed">
-        <thead className="bg-white/10">
+        <thead className="bg-white/10 sticky top-0 z-10">
           <tr>
-            <th className="p-1 whitespace-nowrap">Date</th>
-            <th className="p-1 whitespace-nowrap">In</th>
-            <th className="p-1 whitespace-nowrap">Out</th>
-            <th className="p-1 whitespace-nowrap">Break Start</th>
-            <th className="p-1 whitespace-nowrap">Break End</th>
-            <th className="p-1 whitespace-nowrap">Extra Start</th>
-            <th className="p-1 whitespace-nowrap">Extra End</th>
-            <th className="p-1 whitespace-nowrap">Total Hrs</th>
+            <th className="p-1">Date</th>
+            <th className="p-1">In</th>
+            <th className="p-1">Out</th>
+            <th className="p-1">Break ⬅️</th>
+            <th className="p-1">Break ➡️</th>
+            <th className="p-1">Extra ⬅️</th>
+            <th className="p-1">Extra ➡️</th>
+            <th className="p-1">Extra Hrs</th>
           </tr>
         </thead>
         <tbody>
@@ -88,18 +103,47 @@ function Table({ rows }) {
                 (r.holiday ? ' bg-amber-200/20' : '')
               }
             >
-              <td className="p-1 text-center whitespace-nowrap">{r.date}</td>
-              <td className="p-1 text-center whitespace-nowrap">{r.in}</td>
-              <td className="p-1 text-center whitespace-nowrap">{r.out}</td>
-              <td className="p-1 text-center whitespace-nowrap">{r.breakStart}</td>
-              <td className="p-1 text-center whitespace-nowrap">{r.breakEnd}</td>
-              <td className="p-1 text-center whitespace-nowrap">{r.extraStart}</td>
-              <td className="p-1 text-center whitespace-nowrap">{r.extraEnd}</td>
-              <td className="p-1 text-center whitespace-nowrap">{r.total}</td>
+              <td className="p-1 text-center break-words">{r.date}</td>
+              <td className="p-1 text-center break-words">{r.in}</td>
+              <td className="p-1 text-center break-words">{r.out}</td>
+              <td className="p-1 text-center break-words">{r.breakStart}</td>
+              <td className="p-1 text-center break-words">{r.breakEnd}</td>
+              <td className="p-1 text-center break-words">{r.extraStart}</td>
+              <td className="p-1 text-center break-words">{r.extraEnd}</td>
+              <td className="p-1 text-center break-words">{r.extraTotal}</td>
             </tr>
           ))}
         </tbody>
       </table>
+      <div className="bg-white/20 text-center font-semibold py-1 sticky bottom-0">
+        ✅ Days Worked: {daysWorked} | 🕒 Extra Hours: {extraHours.toFixed(1)}h
+      </div>
+    </div>
+  )
+}
+
+function DayCards({ rows }) {
+  const daysWorked = rows.filter(r => r.in || r.out).length
+  const extraHours = rows.reduce((s, r) => s + (parseFloat(r.extraTotal) || 0), 0)
+  return (
+    <div>
+      <div className="flex overflow-x-auto space-x-2 pb-2">
+        {rows.map(r => (
+          <div
+            key={r.date}
+            className={`min-w-[9rem] flex-shrink-0 bg-white/10 rounded-xl p-2 text-xs ${r.weekend ? 'bg-violet/10' : ''} ${r.holiday ? 'bg-amber-200/20' : ''}`}
+          >
+            <div className="font-semibold mb-1">📅 {r.date}</div>
+            <div>⏰ In: {r.in || '–'} | Out: {r.out || '–'}</div>
+            <div>☕ Break: {r.breakStart || '–'} / {r.breakEnd || '–'}</div>
+            <div>⏱️ Extra: {r.extraStart || '–'} / {r.extraEnd || '–'}</div>
+            <div>➕ Extra Total: {r.extraTotal ? `${r.extraTotal} h` : '– h'}</div>
+          </div>
+        ))}
+      </div>
+      <div className="bg-white/20 text-center font-semibold py-1 rounded-b-xl">
+        ✅ Days Worked: {daysWorked} | 🕒 Extra Hours: {extraHours.toFixed(1)}h
+      </div>
     </div>
   )
 }
@@ -128,25 +172,30 @@ function toRows(events, monthStr) {
       breakEnd: '',
       extraStart: '',
       extraEnd: '',
-      total: '',
+      extraTotal: '',
       weekend: [0, 6].includes(new Date(date).getDay()),
       holiday: false,
     }
     const dayEvents = events.filter((e) => e.timestamp.startsWith(date))
     dayEvents.sort((a, b) => a.timestamp.localeCompare(b.timestamp))
     let lastIn = null
-    let total = 0
+    let lastExtra = null
+    let extraTotal = 0
     dayEvents.forEach((ev) => {
       const key = mapping[ev.kind]
       const time = new Date(ev.timestamp)
       if (key) row[key] = time.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
       if (key === 'in') lastIn = time
       if (key === 'out' && lastIn) {
-        total += (time - lastIn) / 3600000
         lastIn = null
       }
+      if (key === 'extraStart') lastExtra = time
+      if (key === 'extraEnd' && lastExtra) {
+        extraTotal += (time - lastExtra) / 3600000
+        lastExtra = null
+      }
     })
-    if (total) row.total = total.toFixed(2)
+    if (extraTotal) row.extraTotal = extraTotal.toFixed(2)
     rows.push(row)
   }
   return rows


### PR DESCRIPTION
## Summary
- update MonthlySheets to use cards on mobile
- collapse older months with card layout
- add sticky header & totals row to table
- compute extra hours per day

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_6875ad7d85c08321bc654110e0c3bd53