### PR TITLE
Implement persistent header

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import MonthlySheets from './MonthlySheets'
 import PeriodSummary from './PeriodSummary'
 import Performance from './Performance'
 import NavBar from './components/NavBar'
+import Header from './components/Header'
 import { AnimatePresence, motion, useReducedMotion } from 'framer-motion'
 
 export default function App() {
@@ -20,6 +21,7 @@ export default function App() {
 
   return (
     <>
+      <Header />
       <AnimatePresence mode="wait">
         <motion.div
           key={path}
@@ -27,7 +29,7 @@ export default function App() {
           animate={shouldReduce ? {} : { opacity: 1, x: 0 }}
           exit={shouldReduce ? {} : { opacity: 0, x: -50 }}
           transition={{ duration: 0.3 }}
-          className="pt-4 pb-16 min-h-screen"
+          className="pt-[80px] pb-16 min-h-screen"
         >
           <Page />
         </motion.div>

--- a/frontend/src/AttendancePad.jsx
+++ b/frontend/src/AttendancePad.jsx
@@ -77,7 +77,10 @@ export default function AttendancePad() {
     >
       <div className="card w-full text-center">
         <div className="text-xl font-semibold" data-testid="name">{employee}</div>
-        <div className="text-lg">{time.toLocaleString()}</div>
+        <div className="mt-2 inline-block bg-sapphire text-white px-3 py-1 rounded-full">
+          <div>{time.toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}</div>
+          <div className="font-mono tracking-widest">{time.toLocaleTimeString()}</div>
+        </div>
       </div>
       <div className="grid grid-cols-2 gap-4 w-full">
         {actions.map((a) => {

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,0 +1,45 @@
+import { motion } from 'framer-motion'
+
+const titles = {
+  '/': 'Daily Attendance',
+  '/monthly-sheets': 'Monthly Report',
+  '/period-summary': 'Period Summary',
+  '/performance': 'Performance',
+  '/admin-dashboard': 'Admin Dashboard',
+  '/employee-dashboard': 'Employee Dashboard'
+}
+
+export default function Header() {
+  const path = window.location.pathname
+  let title = 'Attendance'
+  for (const p of Object.keys(titles)) {
+    if (path.startsWith(p)) {
+      title = titles[p]
+      break
+    }
+  }
+  return (
+    <header className="fixed top-0 left-0 right-0 z-20 bg-gradient-to-r from-[#004aad] to-[#0e5dad] shadow flex items-center justify-between px-4 h-[60px] md:h-[72px] text-white">
+      <a href="/" className="flex items-center gap-2">
+        <img src="/favicon.ico" alt="Logo" className="w-8 h-8 rounded" />
+      </a>
+      <motion.h1
+        key={title}
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -10 }}
+        transition={{ duration: 0.2 }}
+        className="font-bold text-base md:text-lg text-center"
+      >
+        {title}
+      </motion.h1>
+      <div className="flex items-center gap-4">
+        <div className="relative">
+          <span>🔔</span>
+          <span className="absolute -top-1 -right-2 bg-red-500 text-xs rounded-full px-1">1</span>
+        </div>
+        <div className="w-8 h-8 bg-white text-sapphire rounded-full flex items-center justify-center font-semibold text-sm">JD</div>
+      </div>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- add global header with gradient background
- integrate header across pages
- highlight date and time on the daily attendance page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_68761051ac94832180095d0d17c80353