### PR TITLE
Add timeline cards with status summary

### DIFF
--- a/frontend/src/AttendancePad.jsx
+++ b/frontend/src/AttendancePad.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import RippleButton from './components/RippleButton'
 import { motion, useReducedMotion } from 'framer-motion'
 import { useToast } from './components/Toast'
+import TimelineEntry from './components/TimelineEntry'
 import axios from 'axios'
 
 export default function AttendancePad() {
@@ -9,6 +10,8 @@ export default function AttendancePad() {
   const [time, setTime] = useState(new Date())
   const [events, setEvents] = useState([])
   const [bounce, setBounce] = useState('')
+  const [use24h, setUse24h] = useState(true)
+  const [mood, setMood] = useState('')
   const toast = useToast()
 
   useEffect(() => {
@@ -68,6 +71,64 @@ export default function AttendancePad() {
 
   const timeline = [...events].sort((a, b) => a.timestamp.localeCompare(b.timestamp))
 
+  let status = 'Clocked Out'
+  let statusColor = 'bg-gray-500'
+  if (timeline.length) {
+    const last = timeline[timeline.length - 1]
+    if (last.kind === 'clockout') {
+      status = 'Clocked Out'
+      statusColor = 'bg-gray-500'
+    } else if (last.kind === 'startbreak') {
+      status = 'On Break'
+      statusColor = 'bg-yellow-500'
+    } else {
+      status = 'Clocked In'
+      statusColor = 'bg-green-600'
+    }
+  }
+
+  const summary = (() => {
+    let inTime = null
+    let outTime = null
+    let lastBreak = null
+    let breakMs = 0
+    let lastExtra = null
+    let extraMs = 0
+    timeline.forEach((e) => {
+      const t = new Date(e.timestamp)
+      if (e.kind === 'clockin') inTime = t
+      if (e.kind === 'clockout') outTime = t
+      if (e.kind === 'startbreak') lastBreak = t
+      if (e.kind === 'endbreak' && lastBreak) {
+        breakMs += t - lastBreak
+        lastBreak = null
+      }
+      if (e.kind === 'startextra') lastExtra = t
+      if (e.kind === 'endextra' && lastExtra) {
+        extraMs += t - lastExtra
+        lastExtra = null
+      }
+    })
+    if (lastBreak) breakMs += Date.now() - lastBreak
+    if (lastExtra) extraMs += Date.now() - lastExtra
+    let workMs = 0
+    if (inTime && outTime) workMs = outTime - inTime - breakMs
+    const hoursWorked = workMs > 0 ? workMs / 3600000 : 0
+    const penaltyMs = workMs > 0 ? Math.max(0, 8 * 3600000 - workMs) : 0
+    return {
+      hoursWorked,
+      breakMs,
+      extraMs,
+      penaltyMs,
+    }
+  })()
+
+  const fmt = (ms) => {
+    const h = Math.floor(ms / 3600000)
+    const m = Math.round((ms % 3600000) / 60000)
+    return `${h}h ${m}m`
+  }
+
   return (
     <motion.div
       initial={shouldReduce ? false : { opacity: 0, y: 20 }}
@@ -79,7 +140,10 @@ export default function AttendancePad() {
         <div className="text-xl font-semibold" data-testid="name">{employee}</div>
         <div className="mt-2 inline-block bg-sapphire text-white px-3 py-1 rounded-full">
           <div>{time.toLocaleDateString(undefined, { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' })}</div>
-          <div className="font-mono tracking-widest">{time.toLocaleTimeString()}</div>
+          <div className="font-mono tracking-widest">{time.toLocaleTimeString([], use24h ? {hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false} : {hour: '2-digit', minute: '2-digit', second: '2-digit'})}</div>
+        </div>
+        <div className="mt-2 flex justify-center">
+          <span className={`px-3 py-1 rounded-full text-sm font-semibold text-white ${statusColor}`}>{status}</span>
         </div>
       </div>
       <div className="grid grid-cols-2 gap-4 w-full">
@@ -98,18 +162,33 @@ export default function AttendancePad() {
           )
         })}
       </div>
+      <div className="card w-full text-sm text-center grid grid-cols-2 gap-2">
+        <div>🕒 Hours Worked</div>
+        <div className="font-semibold">{fmt(summary.hoursWorked * 3600000)}</div>
+        <div>🧾 Break</div>
+        <div className="font-semibold">{fmt(summary.breakMs)}</div>
+        <div>➕ Extra Time</div>
+        <div className="font-semibold">{fmt(summary.extraMs)}</div>
+        <div>⚠️ Penalty</div>
+        <div className="font-semibold">{fmt(summary.penaltyMs)}</div>
+      </div>
       <div className="card w-full">
         <h3 className="font-semibold mb-2">Today's Timeline</h3>
-        <ul className="relative border-l border-sapphire pl-4 space-y-2">
-          {timeline.map((e) => (
-            <li key={e.id} className="relative">
-              <span className="absolute -left-2 top-1 w-3 h-3 bg-sapphire rounded-full"></span>
-              {actions.find((a) => a.kind === e.kind)?.icon}{' '}
-              {actions.find((a) => a.kind === e.kind)?.label} -{' '}
-              {new Date(e.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-            </li>
-          ))}
-        </ul>
+        <div className="space-y-2">
+          {timeline.map((e, idx) => {
+            const a = actions.find((x) => x.kind === e.kind)
+            const t = new Date(e.timestamp).toLocaleTimeString([], use24h ? { hour: '2-digit', minute: '2-digit', hour12: false } : { hour: '2-digit', minute: '2-digit' })
+            return <TimelineEntry key={e.id} index={idx} icon={a?.icon} label={a?.label} time={t} />
+          })}
+        </div>
+        <button onClick={() => setUse24h(!use24h)} className="mt-2 text-sapphire underline text-sm">
+          Toggle {use24h ? 'AM/PM' : '24h'}
+        </button>
+      </div>
+      <div className="flex gap-2">
+        {['😃', '🙂', '😐', '🙁', '😡'].map((m) => (
+          <button key={m} onClick={() => setMood(m)} className={`text-2xl ${mood === m ? 'scale-110' : ''}`}>{m}</button>
+        ))}
       </div>
     </motion.div>
   )

--- a/frontend/src/MonthlySheets.jsx
+++ b/frontend/src/MonthlySheets.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import axios from 'axios'
+import TimelineEntry from './components/TimelineEntry'
 
 export default function MonthlySheets() {
   const [employee, setEmployee] = useState('')
@@ -128,18 +129,25 @@ function DayCards({ rows }) {
   return (
     <div>
       <div className="flex overflow-x-auto space-x-2 pb-2">
-        {rows.map(r => (
-          <div
-            key={r.date}
-            className={`min-w-[9rem] flex-shrink-0 bg-white/10 rounded-xl p-2 text-xs ${r.weekend ? 'bg-violet/10' : ''} ${r.holiday ? 'bg-amber-200/20' : ''}`}
-          >
-            <div className="font-semibold mb-1">📅 {r.date}</div>
-            <div>⏰ In: {r.in || '–'} | Out: {r.out || '–'}</div>
-            <div>☕ Break: {r.breakStart || '–'} / {r.breakEnd || '–'}</div>
-            <div>⏱️ Extra: {r.extraStart || '–'} / {r.extraEnd || '–'}</div>
-            <div>➕ Extra Total: {r.extraTotal ? `${r.extraTotal} h` : '– h'}</div>
-          </div>
-        ))}
+        {rows.map(r => {
+          const evs = []
+          if (r.in) evs.push({ label: 'Clock In', icon: '✅', time: r.in })
+          if (r.breakStart) evs.push({ label: 'Start Break', icon: '🛑', time: r.breakStart })
+          if (r.breakEnd) evs.push({ label: 'End Break', icon: '✅', time: r.breakEnd })
+          if (r.out) evs.push({ label: 'Clock Out', icon: '🕔', time: r.out })
+          return (
+            <div
+              key={r.date}
+              className={`min-w-[9rem] flex-shrink-0 bg-white/10 rounded-xl p-2 text-xs space-y-1 ${r.weekend ? 'bg-violet/10' : ''} ${r.holiday ? 'bg-amber-200/20' : ''}`}
+            >
+              <div className="font-semibold mb-1">📅 {r.date}</div>
+              {evs.map((ev, idx) => (
+                <TimelineEntry key={idx} index={idx} icon={ev.icon} label={ev.label} time={ev.time} />
+              ))}
+              <div>➕ Extra Total: {r.extraTotal ? `${r.extraTotal} h` : '– h'}</div>
+            </div>
+          )
+        })}
       </div>
       <div className="bg-white/20 text-center font-semibold py-1 rounded-b-xl">
         ✅ Days Worked: {daysWorked} | 🕒 Extra Hours: {extraHours.toFixed(1)}h

--- a/frontend/src/components/TimelineEntry.jsx
+++ b/frontend/src/components/TimelineEntry.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+const colors = ['bg-blue-500', 'bg-green-500', 'bg-red-500', 'bg-orange-500']
+
+export default function TimelineEntry({ icon, label, time, index }) {
+  const color = colors[index % colors.length]
+  return (
+    <div className={`flex items-center text-white px-2 py-1 rounded ${color}`}>
+      <span className="mr-2">{icon}</span>
+      <span className="flex-1">{label}</span>
+      <span className="font-mono">{time}</span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add `TimelineEntry` component for colorful timeline cards
- show current clock status and time format toggle
- compute quick summary of hours and penalties
- reuse timeline card design in monthly view

## Testing
- `pytest tests/test_routes.py::test_admin_dashboard -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_6876160aefec8321acfaeb7d456d5e76