### PR TITLE
Add edit and payout tabs to admin dashboard

### DIFF
--- a/frontend/src/AdminControlCenter.jsx
+++ b/frontend/src/AdminControlCenter.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react'
 import axios from 'axios'
 import TimelineEntry from './components/TimelineEntry'
+import EditRecords from './EditRecords'
+import PayoutSummary from './PayoutSummary'
 
 const actions = [
   { kind: 'clockin', icon: '✅', label: 'Clock In' },
@@ -223,13 +225,29 @@ function DirectoryTab() {
 
 export default function AdminControlCenter() {
   const [tab, setTab] = useState('overview')
+  const renderTab = () => {
+    switch (tab) {
+      case 'overview':
+        return <OverviewTab />
+      case 'directory':
+        return <DirectoryTab />
+      case 'edit':
+        return <EditRecords />
+      case 'payout':
+        return <PayoutSummary />
+      default:
+        return null
+    }
+  }
   return (
     <div className="p-4 space-y-4">
       <div className="flex space-x-4 border-b pb-2">
         <button className={tab==='overview' ? 'font-bold' : ''} onClick={() => setTab('overview')}>Overview</button>
         <button className={tab==='directory' ? 'font-bold' : ''} onClick={() => setTab('directory')}>Employees Directory</button>
+        <button className={tab==='edit' ? 'font-bold' : ''} onClick={() => setTab('edit')}>Edit Records</button>
+        <button className={tab==='payout' ? 'font-bold' : ''} onClick={() => setTab('payout')}>Payout Summary</button>
       </div>
-      {tab === 'overview' ? <OverviewTab /> : <DirectoryTab />}
+      {renderTab()}
     </div>
   )
 }

--- a/frontend/src/EditRecords.jsx
+++ b/frontend/src/EditRecords.jsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+
+export default function EditRecords() {
+  const [employee, setEmployee] = useState('')
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10))
+  const [entries, setEntries] = useState({})
+  const [showMissing, setShowMissing] = useState(false)
+
+  useEffect(() => {
+    if (!employee) return
+    const m = date.slice(0, 7)
+    axios
+      .get('/api/events', { params: { employee_id: employee, month: m } })
+      .then((res) => {
+        const rows = {}
+        res.data.forEach((e) => {
+          const d = e.timestamp.slice(0, 10)
+          rows[d] = rows[d] || {}
+          rows[d][e.kind] = e
+        })
+        setEntries(rows)
+      })
+      .catch(() => setEntries({}))
+  }, [employee, date])
+
+  const handleChange = async (kind) => {
+    const ts = prompt('ISO timestamp')
+    if (!ts) return
+    const row = entries[date] || {}
+    if (row[kind]) {
+      await axios.patch(`/api/events/${row[kind].id}`, { timestamp: ts })
+    } else if (employee) {
+      await axios.post('/api/events', {
+        employee_id: employee,
+        kind,
+        timestamp: ts,
+      })
+    }
+  }
+
+  const kinds = [
+    ['clockin', 'Clock In'],
+    ['clockout', 'Clock Out'],
+    ['startbreak', 'Break Start'],
+    ['endbreak', 'Break End'],
+    ['startextra', 'Extra Start'],
+    ['endextra', 'Extra End'],
+  ]
+
+  const row = entries[date] || {}
+  const missing = kinds.some(([k]) => !row[k])
+
+  if (showMissing && !missing) return null
+
+  return (
+    <div className="space-y-2">
+      <div className="flex space-x-2">
+        <input
+          className="bg-white/10 p-1 rounded"
+          value={employee}
+          onChange={(e) => setEmployee(e.target.value)}
+          placeholder="Employee"
+        />
+        <input
+          type="date"
+          className="bg-white/10 p-1 rounded"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
+        <label className="flex items-center space-x-1 text-sm">
+          <input
+            type="checkbox"
+            checked={showMissing}
+            onChange={(e) => setShowMissing(e.target.checked)}
+          />
+          <span>Show only days with missing data</span>
+        </label>
+      </div>
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr>
+            <th className="border px-2">Entry</th>
+            <th className="border px-2">Time</th>
+            <th className="border px-2">Edit</th>
+          </tr>
+        </thead>
+        <tbody>
+          {kinds.map(([k, label]) => (
+            <tr key={k} className="text-center">
+              <td className="border px-2">{label}</td>
+              <td className="border px-2">{row[k]?.timestamp?.slice(11, 16) || '-'}</td>
+              <td className="border px-2">
+                <button className="underline" onClick={() => handleChange(k)}>
+                  Edit
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div className="text-right">
+        <button className="underline" onClick={() => window.location.reload()}>Restore Original</button>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/PayoutSummary.jsx
+++ b/frontend/src/PayoutSummary.jsx
@@ -1,0 +1,82 @@
+import { useEffect, useState } from 'react'
+import axios from 'axios'
+
+export default function PayoutSummary() {
+  const [employees, setEmployees] = useState([])
+  const [rates, setRates] = useState({})
+  const [summary, setSummary] = useState({})
+  const [month, setMonth] = useState(() => new Date().toISOString().slice(0,7))
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const res = await axios.get('/api/events', { params: { month } })
+        const byEmp = {}
+        res.data.forEach(e => {
+          const day = e.timestamp.slice(0,10)
+          byEmp[e.employee_id] = byEmp[e.employee_id] || {}
+          byEmp[e.employee_id][day] = true
+        })
+        const employees = Object.keys(byEmp)
+        setEmployees(employees)
+        const summaries = {}
+        employees.forEach(emp => {
+          const days = Object.keys(byEmp[emp]).length
+          summaries[emp] = { days }
+        })
+        setSummary(summaries)
+      } catch {
+        setEmployees([])
+        setSummary({})
+      }
+    }
+    fetchData()
+  }, [month])
+
+  const handleRateChange = (emp, value) => {
+    setRates(prev => ({ ...prev, [emp]: value }))
+  }
+
+  return (
+    <div className="space-y-2">
+      <input
+        type="month"
+        className="bg-white/10 p-1 rounded"
+        value={month}
+        onChange={e => setMonth(e.target.value)}
+      />
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr>
+            <th className="border px-2">Employee</th>
+            <th className="border px-2">Day Price (DH)</th>
+            <th className="border px-2">Worked Days</th>
+            <th className="border px-2">Base Pay</th>
+          </tr>
+        </thead>
+        <tbody>
+          {employees.map(emp => {
+            const rate = rates[emp] || 0
+            const days = summary[emp]?.days || 0
+            const base = (rate * days).toFixed(2)
+            return (
+              <tr key={emp} className="text-center">
+                <td className="border px-2">{emp}</td>
+                <td className="border px-2">
+                  <input
+                    type="number"
+                    value={rate}
+                    onChange={e => handleRateChange(emp, e.target.value)}
+                    className="bg-white/10 p-1 rounded w-24 text-right"
+                  />
+                </td>
+                <td className="border px-2">{days}</td>
+                <td className="border px-2">{base}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- extend AdminControlCenter with Edit Records and Payout Summary tabs
- implement EditRecords component to modify attendance events
- implement PayoutSummary component for simple payout calculations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: testcontainers)*

------
https://chatgpt.com/codex/tasks/task_e_687621d5a6b8832184277a4c193f1d39