### PR TITLE
Improve light theme editing UI

### DIFF
--- a/frontend/src/EditRecords.jsx
+++ b/frontend/src/EditRecords.jsx
@@ -2,10 +2,22 @@ import { useEffect, useState } from 'react'
 import axios from 'axios'
 
 export default function EditRecords() {
+  const [employees, setEmployees] = useState([])
   const [employee, setEmployee] = useState('')
   const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10))
   const [entries, setEntries] = useState({})
   const [showMissing, setShowMissing] = useState(false)
+
+  useEffect(() => {
+    const m = new Date().toISOString().slice(0, 7)
+    axios
+      .get('/api/events', { params: { month: m } })
+      .then(res => {
+        const ids = Array.from(new Set(res.data.map(e => e.employee_id)))
+        setEmployees(ids)
+      })
+      .catch(() => setEmployees([]))
+  }, [])
 
   useEffect(() => {
     if (!employee) return
@@ -54,35 +66,50 @@ export default function EditRecords() {
   if (showMissing && !missing) return null
 
   return (
-    <div className="space-y-2">
-      <div className="flex flex-col space-y-2 md:flex-row md:space-y-0 md:space-x-2">
-        <input
-          className="bg-white/10 p-2 rounded-md"
+    <div className="card space-y-4 relative">
+      <button
+        className="absolute top-2 right-2 px-3 py-1 border border-gray-300 rounded text-sm hover:bg-gray-50"
+        onClick={() => window.location.reload()}
+      >
+        Restore Original
+      </button>
+      <div className="flex flex-col gap-2 md:flex-row md:items-center">
+        <select
+          className="rounded-lg p-2 border border-gray-300 w-full shadow-sm"
           value={employee}
-          onChange={(e) => setEmployee(e.target.value)}
-          placeholder="Employee"
-        />
+          onChange={(e) => {
+            setEmployee(e.target.value)
+            setDate(new Date().toISOString().slice(0, 10))
+          }}
+        >
+          <option disabled value="">
+            Select Employee
+          </option>
+          {employees.map((emp) => (
+            <option key={emp}>{emp}</option>
+          ))}
+        </select>
         <div className="relative">
           <input
             type="date"
-            className="bg-white/10 p-2 pr-8 rounded-md w-full"
+            className="rounded-lg p-2 pr-8 border border-gray-300 shadow-sm w-full"
             value={date}
             onChange={(e) => setDate(e.target.value)}
           />
-          <span className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none">📅</span>
+          <span className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none">📅</span>
         </div>
-        <label className="flex items-center space-x-1 text-sm">
+        <label className="flex items-center space-x-2 text-sm">
           <input
             type="checkbox"
-            className="accent-sapphire mr-1"
+            className="toggle-switch"
             checked={showMissing}
             onChange={(e) => setShowMissing(e.target.checked)}
           />
           <span>Show only days with missing data</span>
         </label>
       </div>
-      <table className="min-w-full text-sm table-hover">
-        <thead>
+      <table className="min-w-full text-sm table-hover border border-gray-200 rounded-lg overflow-hidden">
+        <thead className="bg-gray-50">
           <tr>
             <th className="border px-2">Entry</th>
             <th className="border px-2">Time</th>
@@ -93,19 +120,20 @@ export default function EditRecords() {
           {kinds.map(([k, label]) => (
             <tr key={k} className="text-center">
               <td className="border px-2">{label}</td>
-              <td className="border px-2">{row[k]?.timestamp?.slice(11, 16) || '-'}</td>
+              <td className="border px-2">{row[k]?.timestamp?.slice(11, 16) || '--'}</td>
               <td className="border px-2">
-                <button className="underline" onClick={() => handleChange(k)}>
-                  Edit
+                <button
+                  className="text-sapphire hover:underline flex items-center gap-1"
+                  onClick={() => handleChange(k)}
+                >
+                  <span>✏️</span>
+                  <span>Edit</span>
                 </button>
               </td>
             </tr>
           ))}
         </tbody>
       </table>
-      <div className="text-right">
-        <button className="underline" onClick={() => window.location.reload()}>Restore Original</button>
-      </div>
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,9 +5,9 @@
 :root {
   font-family: Inter, system-ui, sans-serif;
   --color-primary: #004AAD;
-  --color-bg-start: #0a0f24;
-  --color-bg-end: #2a2b2f;
-  --color-foreground: #f9fafb;
+  --color-bg-start: #f9fafb;
+  --color-bg-end: #ffffff;
+  --color-foreground: #1f2937;
   --color-emerald: #10b981;
   --color-coral: #f87171;
   --color-sapphire: #3b82f6;
@@ -24,12 +24,12 @@
 
 body {
   font-family: Inter, system-ui, sans-serif;
-  background: linear-gradient(to bottom, var(--color-bg-start), var(--color-bg-end));
+  background-color: var(--color-bg-start);
   color: var(--color-foreground);
 }
 
 .card {
-  @apply bg-white/10 backdrop-blur-md rounded-xl p-6 shadow-md;
+  @apply bg-white rounded-xl p-6 shadow border border-gray-200;
 }
 
 .btn {
@@ -60,9 +60,7 @@ body {
 }
 
 .table-hover tbody tr:hover {
-  background-color: rgba(255, 255, 255, 0.05);
-  transform: translateX(4px);
-  transition: all var(--motion-duration) var(--motion-curve);
+  background-color: #e0f2fe;
 }
 
 .badge {
@@ -70,11 +68,11 @@ body {
 }
 
 .tab {
-  @apply px-3 py-1 rounded-lg font-medium text-white whitespace-nowrap;
+  @apply px-3 py-1 rounded-lg font-medium text-gray-800 whitespace-nowrap;
 }
 
 .tab-active {
-  @apply bg-white/20 shadow;
+  @apply bg-gray-200 shadow;
 }
 
 .ripple {
@@ -91,4 +89,18 @@ body {
     transform: scale(4);
     opacity: 0;
   }
+}
+
+.toggle-switch {
+  @apply relative inline-block w-10 h-5 cursor-pointer appearance-none bg-gray-300 rounded-full transition-colors;
+}
+.toggle-switch:checked {
+  @apply bg-sapphire;
+}
+.toggle-switch:before {
+  content: '';
+  @apply absolute left-1 top-1 h-3 w-3 rounded-full bg-white transition-transform;
+}
+.toggle-switch:checked:before {
+  transform: translateX(20px);
 }


### PR DESCRIPTION
## Summary
- switch to light theme colors and update card styles
- add toggle switch and dropdown select in Edit Records

## Testing
- `npm test --prefix frontend` *(fails: Missing script)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'testcontainers')*

------
https://chatgpt.com/codex/tasks/task_e_687651cd699483218db266da0c6273a1