### PR TITLE
Add PWA config without icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ npm run dev     # development mode
 npm run build   # production build
 ```
 
+Building now generates a service worker via `vite-plugin-pwa`. Make sure to run
+`npm install` after pulling updates so the plugin is available.
+
 During development the Vite dev server serves the app on `http://localhost:5173`
 and API requests are sent to the backend running on `http://localhost:8080`.
 When deploying, the Dockerfile builds the frontend and copies the compiled

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="theme-color" content="#ffffff" />
+    <link rel="manifest" href="/manifest.webmanifest" />
     <title>Attendance</title>
   </head>
   <body class="bg-background text-foreground transition-colors">

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.27",
     "tailwindcss": "^3.3.2",
-    "@vitejs/plugin-react": "^4.1.0"
+    "@vitejs/plugin-react": "^4.1.0",
+    "vite-plugin-pwa": "^0.16.0"
   }
 }

--- a/frontend/public/manifest.webmanifest
+++ b/frontend/public/manifest.webmanifest
@@ -1,0 +1,20 @@
+{
+  "name": "Attendance",
+  "short_name": "Attendance",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "/icon-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/icon-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -20,3 +20,9 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     </QueryClientProvider>
   </React.StrictMode>
 )
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/sw.js')
+  })
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,34 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    VitePWA({
+      registerType: 'autoUpdate',
+      manifest: {
+        name: 'Attendance',
+        short_name: 'Attendance',
+        start_url: '/',
+        display: 'standalone',
+        background_color: '#ffffff',
+        theme_color: '#ffffff',
+        icons: [
+          {
+            src: '/icon-192.png',
+            sizes: '192x192',
+            type: 'image/png'
+          },
+          {
+            src: '/icon-512.png',
+            sizes: '512x512',
+            type: 'image/png'
+          }
+        ]
+      }
+    })
+  ],
   server: {
     port: 3000
   }


### PR DESCRIPTION
## Summary
- set up manifest and PWA plugin
- register service worker
- link manifest and theme color in index.html
- document new build requirements
- remove icon files from repo

## Testing
- `PYTHONPATH=. pytest -q` *(fails: docker errors and async fixture issues)*

------
https://chatgpt.com/codex/tasks/task_e_6878027b6dcc83219cd8a58bc59677a0