### PR TITLE
Fix time handling in dashboards

### DIFF
--- a/frontend/src/EditRecords.jsx
+++ b/frontend/src/EditRecords.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import axios from 'axios'
 import { useToast } from './components/Toast'
+import { formatHoursHM } from './utils'
 
 const kinds = [
   ['clockin', 'Clock In'],
@@ -63,7 +64,13 @@ export default function EditRecords() {
   }, [employee, monthStr])
 
   const startEdit = (date, kind, row) => {
-    const val = row[kind]?.timestamp?.slice(11, 16) || ''
+    const val = row[kind]
+      ? new Date(row[kind].timestamp).toLocaleTimeString([], {
+          hour: '2-digit',
+          minute: '2-digit',
+          hour12: false,
+        })
+      : ''
     setEditing({ date, kind, value: val })
   }
 
@@ -207,7 +214,12 @@ export default function EditRecords() {
                         </button>
                       </div>
                     ) : (
-                      row[k]?.timestamp?.slice(11, 16) || '—'
+                      row[k]
+                        ? new Date(row[k].timestamp).toLocaleTimeString([], {
+                            hour: '2-digit',
+                            minute: '2-digit',
+                          })
+                        : '—'
                     )}
                   </td>
                 ))}
@@ -216,7 +228,7 @@ export default function EditRecords() {
           </tbody>
         </table>
         <div className="font-semibold text-center">
-          Worked Days {workedDays} • Worked Hours {workedHours.toFixed(2)} • Extra Hours {extraHours.toFixed(2)}
+          Worked Days {workedDays} • Worked Hours {formatHoursHM(workedHours)} • Extra Hours {formatHoursHM(extraHours)}
         </div>
       </div>
     </div>

--- a/frontend/src/EmployeeDashboard.jsx
+++ b/frontend/src/EmployeeDashboard.jsx
@@ -4,7 +4,7 @@ import axios from 'axios'
 import { Line, Doughnut } from 'react-chartjs-2'
 import { Chart, ArcElement, LineElement, CategoryScale, LinearScale, PointElement, Tooltip, Legend } from 'chart.js'
 import { Progress } from './components/ProgressBar'
-import { formatHours } from './utils'
+import { formatHoursHM } from './utils'
 
 Chart.register(ArcElement, LineElement, CategoryScale, LinearScale, PointElement, Tooltip, Legend)
 
@@ -56,7 +56,7 @@ export default function EmployeeDashboard() {
         <Doughnut data={donutData} />
         <Line data={lineData} />
       </div>
-      <Progress value={progress} label={`Hours: ${formatHours(data.total_hours)}/${goal}`} />
+      <Progress value={progress} label={`Hours: ${formatHoursHM(data.total_hours)}/${goal}`} />
       <table className="min-w-full text-sm table-hover">
         <thead>
           <tr>
@@ -68,7 +68,7 @@ export default function EmployeeDashboard() {
           {days.map((d) => (
             <tr key={d}>
               <td className="border px-2">{d}</td>
-              <td className="border px-2">{formatHours(data.hours_per_day[d])}</td>
+              <td className="border px-2">{formatHoursHM(data.hours_per_day[d])}</td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/MonthlySheets.jsx
+++ b/frontend/src/MonthlySheets.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import axios from 'axios'
 import TimelineEntry from './components/TimelineEntry'
+import { formatHoursHM } from './utils'
 
 export default function MonthlySheets() {
   const [employee, setEmployee] = useState('')
@@ -78,7 +79,7 @@ export default function MonthlySheets() {
 
 function Table({ rows }) {
   const daysWorked = rows.filter(r => r.in || r.out).length
-  const extraHours = rows.reduce((s, r) => s + (parseFloat(r.extraTotal) || 0), 0)
+  const extraHours = rows.reduce((s, r) => s + (r.extraTotal || 0), 0)
   return (
     <div className="overflow-auto">
       <table className="w-full text-xs sm:text-sm table-fixed">
@@ -111,13 +112,13 @@ function Table({ rows }) {
               <td className="p-1 text-center break-words">{r.breakEnd}</td>
               <td className="p-1 text-center break-words">{r.extraStart}</td>
               <td className="p-1 text-center break-words">{r.extraEnd}</td>
-              <td className="p-1 text-center break-words">{r.extraTotal}</td>
+              <td className="p-1 text-center break-words">{r.extraTotal ? formatHoursHM(r.extraTotal) : ''}</td>
             </tr>
           ))}
         </tbody>
       </table>
       <div className="bg-white/20 text-center font-semibold py-1 sticky bottom-0">
-        ✅ Days Worked: {daysWorked} | 🕒 Extra Hours: {extraHours.toFixed(1)}h
+        ✅ Days Worked: {daysWorked} | 🕒 Extra Hours: {formatHoursHM(extraHours)}
       </div>
     </div>
   )
@@ -125,7 +126,7 @@ function Table({ rows }) {
 
 function DayCards({ rows }) {
   const daysWorked = rows.filter(r => r.in || r.out).length
-  const extraHours = rows.reduce((s, r) => s + (parseFloat(r.extraTotal) || 0), 0)
+  const extraHours = rows.reduce((s, r) => s + (r.extraTotal || 0), 0)
   return (
     <div>
       <div className="flex overflow-x-auto space-x-2 pb-2">
@@ -144,13 +145,13 @@ function DayCards({ rows }) {
               {evs.map((ev, idx) => (
                 <TimelineEntry key={idx} index={idx} icon={ev.icon} label={ev.label} time={ev.time} />
               ))}
-              <div>➕ Extra Total: {r.extraTotal ? `${r.extraTotal} h` : '– h'}</div>
+              <div>➕ Extra Total: {r.extraTotal ? formatHoursHM(r.extraTotal) : '– h'}</div>
             </div>
           )
         })}
       </div>
       <div className="bg-white/20 text-center font-semibold py-1 rounded-b-xl">
-        ✅ Days Worked: {daysWorked} | 🕒 Extra Hours: {extraHours.toFixed(1)}h
+        ✅ Days Worked: {daysWorked} | 🕒 Extra Hours: {formatHoursHM(extraHours)}
       </div>
     </div>
   )
@@ -203,7 +204,7 @@ function toRows(events, monthStr) {
         lastExtra = null
       }
     })
-    if (extraTotal) row.extraTotal = extraTotal.toFixed(2)
+    if (extraTotal) row.extraTotal = extraTotal
     rows.push(row)
   }
   return rows

--- a/frontend/src/PayoutSummary.jsx
+++ b/frontend/src/PayoutSummary.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import axios from 'axios'
+import { formatHoursHM } from './utils'
 
 export default function PayoutSummary() {
   const [month, setMonth] = useState(() => new Date().toISOString().slice(0, 7))
@@ -183,7 +184,7 @@ export default function PayoutSummary() {
                 </div>
                 <div className="flex justify-between">
                   <span>Worked Hours</span>
-                  <span className="font-semibold">{d.hours.toFixed(2)}</span>
+                  <span className="font-semibold">{formatHoursHM(d.hours)}</span>
                 </div>
                 <div className="flex justify-between">
                   <span>Base Pay</span>

--- a/frontend/src/components/EmployeeInlineDashboard.jsx
+++ b/frontend/src/components/EmployeeInlineDashboard.jsx
@@ -3,7 +3,7 @@ import axios from 'axios'
 import { Line, Doughnut } from 'react-chartjs-2'
 import { Chart, ArcElement, LineElement, CategoryScale, LinearScale, PointElement, Tooltip, Legend } from 'chart.js'
 import { Progress } from './ProgressBar'
-import { formatHours } from '../utils'
+import { formatHoursHM } from '../utils'
 
 Chart.register(ArcElement, LineElement, CategoryScale, LinearScale, PointElement, Tooltip, Legend)
 
@@ -41,7 +41,7 @@ export default function EmployeeInlineDashboard({ employee }) {
         <Doughnut data={donutData} />
         <Line data={lineData} />
       </div>
-      <Progress value={progress} label={`Hours: ${formatHours(data.total_hours)}/${goal}`} />
+      <Progress value={progress} label={`Hours: ${formatHoursHM(data.total_hours)}/${goal}`} />
       <table className="min-w-full text-sm table-hover">
         <thead>
           <tr>
@@ -53,7 +53,7 @@ export default function EmployeeInlineDashboard({ employee }) {
           {days.map(d => (
             <tr key={d}>
               <td className="border px-2">{d}</td>
-              <td className="border px-2">{formatHours(data.hours_per_day[d])}</td>
+              <td className="border px-2">{formatHoursHM(data.hours_per_day[d])}</td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -10,3 +10,11 @@ export function formatHours(hours) {
 export function formatMs(ms) {
   return formatHours(ms / 3600000);
 }
+
+export function formatHoursHM(hours) {
+  const totalMinutes = Math.round(hours * 60)
+  const h = Math.floor(totalMinutes / 60)
+  const m = totalMinutes % 60
+  const pad = (n) => n.toString().padStart(2, '0')
+  return `${pad(h)}:${pad(m)}`
+}


### PR DESCRIPTION
## Summary
- show times in local timezone in EditRecords
- add `formatHoursHM` helper for HH:MM output
- use new helper across employee dashboards and payout summary
- display extra hours formatted in MonthlySheets

## Testing
- `pip install -r requirements-dev.txt`
- `pip install -r requirements.txt`
- `pytest -q` *(fails: Docker not available)*

------
https://chatgpt.com/codex/tasks/task_e_6879778f5fac83219dd38131ada26b9e