### PR TITLE
Improve PeriodSummary UI

### DIFF
--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -18,3 +18,17 @@ export function formatHoursHM(hours) {
   const pad = (n) => n.toString().padStart(2, '0')
   return `${pad(h)}:${pad(m)}`
 }
+
+export function formatHoursHMLabel(hours) {
+  const [h, m] = formatHoursHM(hours).split(':')
+  return `${Number(h)} h ${m} m`
+}
+
+export function formatDaysHM(days) {
+  const wholeDays = Math.floor(days)
+  const remainingHours = (days - wholeDays) * 8
+  const h = Math.floor(remainingHours)
+  const m = Math.round((remainingHours - h) * 60)
+  const pad = (n) => n.toString().padStart(2, '0')
+  return `${wholeDays} day${wholeDays === 1 ? '' : 's'} ${h} h ${pad(m)} m`
+}


### PR DESCRIPTION
## Summary
- default active period uses current day for highlight
- add readable day/hour formatting helpers
- update period summary UI with totals strip and badges

## Testing
- `pytest -q` *(fails: Docker daemon unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68799a3f621c8321a3b0d2751b458805