### PR TITLE
Trim pre-clockin events

### DIFF
--- a/frontend/src/AdminControlCenter.jsx
+++ b/frontend/src/AdminControlCenter.jsx
@@ -15,7 +15,7 @@ import EditRecords from './EditRecords'
 import PayoutSummary from './PayoutSummary'
 import SettingsLogs from './SettingsLogs'
 import AdminHeader from './components/AdminHeader'
-import { formatMs } from './utils'
+import { formatMs, stripPreClockin } from './utils'
 import useSettings from './useSettings'
 
 Chart.register(BarElement, CategoryScale, LinearScale, ArcElement, Tooltip, Legend)
@@ -113,7 +113,11 @@ function OverviewTab() {
           byEmp[e.employee_id] = byEmp[e.employee_id] || []
           byEmp[e.employee_id].push(e)
         })
-        setData(Object.entries(byEmp).map(([id, ev]) => ({ id, events: ev })))
+        const arr = Object.entries(byEmp).map(([id, ev]) => ({
+          id,
+          events: stripPreClockin(ev)
+        }))
+        setData(arr)
       } catch {
         /* ignore */
       }
@@ -277,7 +281,7 @@ function DirectoryTab() {
           })
           let extraMs = 0
           Object.values(byDay).forEach(dayEv => {
-            extraMs += computeMetrics(dayEv, settings.WORK_DAY_HOURS, settings.GRACE_PERIOD_MIN).extraMs
+            extraMs += computeMetrics(stripPreClockin(dayEv), settings.WORK_DAY_HOURS, settings.GRACE_PERIOD_MIN).extraMs
           })
           return {
             id,
@@ -315,7 +319,7 @@ function DirectoryTab() {
         <tbody>
           {employees.filter(e => e.id.toLowerCase().includes(query.toLowerCase())).map(emp => {
             const today = new Date().toISOString().slice(0,10)
-            const todays = emp.events?.filter(e => e.timestamp.startsWith(today)) || []
+            const todays = stripPreClockin(emp.events?.filter(e => e.timestamp.startsWith(today)) || [])
             const status = todays.length ? computeMetrics(todays, settings.WORK_DAY_HOURS, settings.GRACE_PERIOD_MIN).status : 'Clocked Out'
             return (
               <>

--- a/frontend/src/AttendancePad.jsx
+++ b/frontend/src/AttendancePad.jsx
@@ -5,6 +5,7 @@ import { useToast } from './components/Toast'
 import TimelineEntry from './components/TimelineEntry'
 import axios from 'axios'
 import useSettings from './useSettings'
+import { stripPreClockin } from './utils'
 
 export default function AttendancePad() {
   const settings = useSettings()
@@ -29,7 +30,8 @@ export default function AttendancePad() {
       .get('/api/events', { params: { employee_id: employee, month } })
       .then((res) => {
         const today = new Date().toISOString().slice(0, 10)
-        setEvents(res.data.filter((e) => e.timestamp.startsWith(today)))
+        const filtered = res.data.filter((e) => e.timestamp.startsWith(today))
+        setEvents(stripPreClockin(filtered))
       })
       .catch(() => {})
   }, [employee])
@@ -56,7 +58,7 @@ export default function AttendancePad() {
   }, [])
 
   const isExtraOpen = () => {
-    const sorted = [...events].sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+    const sorted = stripPreClockin([...events].sort((a, b) => a.timestamp.localeCompare(b.timestamp)))
     let open = false
     sorted.forEach((e) => {
       if (e.kind === 'startextra') open = true
@@ -85,7 +87,7 @@ export default function AttendancePad() {
         params: { employee_id: employee, kind: action, timestamp: ts }
       })
       .then((res) => {
-        setEvents([...events, { id: res.data.id, kind: action, timestamp: ts }])
+        setEvents(stripPreClockin([...events, { id: res.data.id, kind: action, timestamp: ts }]))
         toast('Saved!')
         setBounce(action)
         setTimeout(() => setBounce(''), 250)
@@ -104,7 +106,7 @@ export default function AttendancePad() {
     { kind: 'endextra', icon: '🛑', label: 'End Extra Hours', color: 'sapphire' },
   ]
 
-  const timeline = [...events].sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+  const timeline = stripPreClockin([...events].sort((a, b) => a.timestamp.localeCompare(b.timestamp)))
 
   let status = 'Clocked Out'
   let statusColor = 'bg-gray-500'

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -32,3 +32,10 @@ export function formatDaysHM(days) {
   const pad = (n) => n.toString().padStart(2, '0')
   return `${wholeDays} day${wholeDays === 1 ? '' : 's'} ${h} h ${pad(m)} m`
 }
+
+export function stripPreClockin(events) {
+  const sorted = [...events].sort((a, b) => a.timestamp.localeCompare(b.timestamp))
+  const idx = sorted.findIndex(e => e.kind === 'clockin' || e.kind === 'in')
+  if (idx === -1) return []
+  return sorted.slice(idx)
+}


### PR DESCRIPTION
## Summary
- ignore events that occur before the day's first clock-in
- derive employee status using the cleaned event list
- share helper `stripPreClockin` in `utils`

## Testing
- `PYTHONPATH=. pytest -q` *(fails: Docker daemon not found)*

------
https://chatgpt.com/codex/tasks/task_e_687be9e8ee488321912a3332caf1954d